### PR TITLE
Use absolute time in tracing and sampling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ find_package(Boost
              REQUIRED COMPONENTS
              graph regex filesystem system)
 
+message(STATUS "Boost_INCLUDE_DIRS: " ${Boost_INCLUDE_DIRS})
 message(STATUS "Boost_LIBRARY_DIRS: " ${Boost_LIBRARY_DIRS})
 
 # This shouldn't be here, but is ok for now. This will occasionally be

--- a/cmake/modules/SetupIHeap.cmake
+++ b/cmake/modules/SetupIHeap.cmake
@@ -4,7 +4,7 @@
 
 set(WCS_HAS_IHEAP TRUE)
 set(IHEAP_SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/iheap)
-set(IHEAP_HEADER iheap.hpp)
+set(IHEAP_HEADER iheap.h)
 
 find_file(IHEAP ${IHEAP_HEADER}
           HINTS ${IHEAP_SOURCE_DIR}
@@ -18,7 +18,8 @@ if (IHEAP)
 else ()
   message(STATUS "iheap will be downloaded.")
   ExternalProject_Add(IHEAP
-    GIT_REPOSITORY https://github.com/yangle/iheap.git
+    DOWNLOAD_COMMAND "${CMAKE_SOURCE_DIR}/external/get_iheap.sh;${CMAKE_SOURCE_DIR}/external"
+    #GIT_REPOSITORY https://github.com/yangle/iheap.git
     SOURCE_DIR "${IHEAP_SOURCE_DIR}"
     LOG_DOWNLOAD ON
     STEP_TARGETS download
@@ -26,7 +27,6 @@ else ()
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     LOG_PATCH ON
-    #PATCH_COMMAND "patch ${IHEAP_SOURCE_DIR}/iheap.h < ${CMAKE_SOURCE_DIR}/external/patch_iheap_h.txt"
   )
 
   unset(IHEAP_DIR CACHE)

--- a/external/get_iheap.sh
+++ b/external/get_iheap.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ $# -ne 1 ] ; then
+  working_dir=.
+else
+  working_dir=$1
+fi
+
+pushd ${working_dir} > /dev/null
+
+if [ ! -d iheap ] || [ ! -f iheap/iheap.h ] ; then
+  git clone https://github.com/yangle/iheap.git
+  patch --no-backup-if-mismatch iheap/iheap.h < patch_iheap_h.txt
+fi
+
+popd > /dev/null

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -172,6 +172,16 @@ void Network::init()
   sort_species();
 }
 
+/// Overwrite the reaction rate to a given value
+void Network::set_reaction_rate(const Network::v_desc_t r,
+                                const wcs::reaction_rate_t rate) const
+{
+  using r_prop_t = wcs::Reaction<v_desc_t>;
+  const auto& rv = m_graph[r]; // vertex (property) of the reaction
+  auto& rp = rv.property<r_prop_t>(); // detailed vertex property data
+  rp.set_rate(rate);
+}
+
 /**
  * Computes the reaction rate based on the population of the reaction driving
  * species and the reaction constant.

--- a/src/reaction_network/network.hpp
+++ b/src/reaction_network/network.hpp
@@ -86,6 +86,7 @@ class Network {
   /// Load an input Graph ML file
   void load(const std::string graphml_filename);
   void init();
+  void set_reaction_rate(const v_desc_t r, const reaction_rate_t rate) const;
   reaction_rate_t set_reaction_rate(const v_desc_t r) const;
   reaction_rate_t get_reaction_rate(const v_desc_t r) const;
 

--- a/src/reaction_network/reaction_base.cpp
+++ b/src/reaction_network/reaction_base.cpp
@@ -132,6 +132,11 @@ reaction_rate_t ReactionBase::calc_rate(std::vector<reaction_rate_t> params)
   return m_rate;
 }
 
+void ReactionBase::set_rate(const reaction_rate_t rate)
+{
+  m_rate = rate;
+}
+
 reaction_rate_t ReactionBase::get_rate() const
 {
   return m_rate;

--- a/src/reaction_network/reaction_base.hpp
+++ b/src/reaction_network/reaction_base.hpp
@@ -49,6 +49,8 @@ class ReactionBase : public VertexPropertyBase {
   void set_calc_rate_fn(const std::function<
                           reaction_rate_t (const std::vector<reaction_rate_t>&)
                         >& calc_rate);
+  /// Overwrite the reaction rate to a given value
+  void set_rate(const reaction_rate_t rate);
   reaction_rate_t get_rate() const;
   void set_rate_formula(const std::string& f);
   const std::string& get_rate_formula() const;

--- a/src/sim_methods/sim_method.cpp
+++ b/src/sim_methods/sim_method.cpp
@@ -26,8 +26,7 @@ Sim_Method::Sim_Method()
   m_sample_iter_interval(static_cast<sim_iter_t>(0u)),
   m_sample_time_interval(static_cast<sim_time_t>(0)),
   m_next_sample_iter(static_cast<sim_iter_t>(0u)),
-  m_next_sample_time(static_cast<sim_time_t>(0)),
-  dt_sample(static_cast<sim_time_t>(0))
+  m_next_sample_time(static_cast<sim_time_t>(0))
 {
   using directed_category
     = typename boost::graph_traits<wcs::Network::graph_t>::directed_category;
@@ -85,34 +84,30 @@ void Sim_Method::record_initial_state(const std::shared_ptr<wcs::Network>& net_p
   }
 }
 
-void Sim_Method::record_final_state(const sim_time_t dt, const v_desc_t rv)
+void Sim_Method::record_final_state(const v_desc_t rv)
 {
   if (m_enable_tracing) {
-    m_trace.record_reaction(dt, rv);
+    m_trace.record_reaction(m_sim_time, rv);
   } else if (m_enable_sampling) {
     m_samples.record_reaction(rv);
-    dt_sample += dt;
-    m_samples.take_sample(dt_sample);
+    m_samples.take_sample(m_sim_time);
   }
 }
 
-bool Sim_Method::check_to_record(const sim_time_t dt, const v_desc_t rv)
+bool Sim_Method::check_to_record(const v_desc_t rv)
 {
   if (m_enable_tracing) {
-    m_trace.record_reaction(dt, rv);
+    m_trace.record_reaction(m_sim_time, rv);
     return true;
   } else if (m_enable_sampling) {
     m_samples.record_reaction(rv);
-    dt_sample += dt;
     if (m_cur_iter >= m_next_sample_iter) {
       m_next_sample_iter += m_sample_iter_interval;
-      m_samples.take_sample(dt_sample);
-      dt_sample = 0.0;
+      m_samples.take_sample(m_sim_time);
       return true;
     } else if (m_sim_time >= m_next_sample_time) {
       m_next_sample_time += m_sample_time_interval;
-      m_samples.take_sample(dt_sample);
-      dt_sample = 0.0;
+      m_samples.take_sample(m_sim_time);
       return true;
     } else {
       return false;

--- a/src/sim_methods/sim_method.cpp
+++ b/src/sim_methods/sim_method.cpp
@@ -148,5 +148,220 @@ Sim_Method::samples_t& Sim_Method::samples() {
 }
 
 
+/**
+ * Execute the chosen reaction.
+ * In other words, update the species population involved in the reaction.
+ * In addition, record how the species are updated, and which other reactions
+ * are affected as a result.
+ * The former can be used to undo the reaction if needed. The latter is used
+ * to update the propensity of the reactions affected by the changes in species
+ * counts.
+ */
+bool Sim_Method::fire_reaction(
+       const Sim_Method::v_desc_t vd_firing,
+       Sim_Method::update_list_t& updating_species,
+       Sim_Method::affected_reactions_t& affected_reactions)
+{
+  using s_prop_t = wcs::Species;
+
+  // Reactions do not change the connectivity, but only change the property
+  // data, which are allocated outside of BGL graph, but only linked to it.
+  const wcs::Network::graph_t& g = m_net_ptr->graph();
+
+  updating_species.clear();
+  affected_reactions.clear();
+
+  // reactant species
+  for (const auto ei_in :
+       boost::make_iterator_range(boost::in_edges(vd_firing, g)))
+  {
+    const auto vd_updating = boost::source(ei_in, g);
+    const auto& sv_updating = g[vd_updating];
+    if constexpr (wcs::Vertex::_num_vertex_types_  > 3) {
+      // in case that there are other type of vertices than species or reaction
+      if (sv_updating.get_type() != wcs::Vertex::_species_) continue;
+    }
+
+    auto& sp_updating = sv_updating.property<s_prop_t>();
+    const auto stoichio = g[ei_in].get_stoichiometry_ratio();
+    if (stoichio == static_cast<stoic_t>(0)) {
+      continue;
+    }
+    if (!sp_updating.dec_count(stoichio)) { // State update
+      std::string err = "Not enough reactants of " + sv_updating.get_label()
+                      + "[" + std::to_string(sp_updating.get_count())
+                      + "] for reaction " + g[vd_firing].get_label();
+      WCS_THROW(err);
+      return false;
+    }
+    updating_species.emplace_back(std::make_pair(vd_updating, -stoichio));
+
+    for (const auto vi_affected :
+         boost::make_iterator_range(boost::out_edges(vd_updating, g)))
+    {
+      const auto vd_affected = boost::target(vi_affected, g);
+      if (vd_affected == vd_firing) continue;
+      affected_reactions.insert(vd_affected);
+    }
+  }
+
+  // product species
+  for (const auto ei_out :
+       boost::make_iterator_range(boost::out_edges(vd_firing, g)))
+  {
+    const auto vd_updating = boost::target(ei_out, g);
+    const auto& sv_updating = g[vd_updating];
+    if constexpr (wcs::Vertex::_num_vertex_types_  > 3) {
+      // in case that there are other type of vertices than species or reaction
+      if (sv_updating.get_type() != wcs::Vertex::_species_) continue;
+    }
+
+    auto& sp_updating = sv_updating.property<s_prop_t>();
+    const auto stoichio = g[ei_out].get_stoichiometry_ratio();
+    if (stoichio == static_cast<stoic_t>(0)) {
+      continue;
+    }
+    if (!sp_updating.inc_count(stoichio)) { // State update
+      std::string err = "Can not produce more of " + sv_updating.get_label()
+                      + "[" + std::to_string(sp_updating.get_count())
+                      + "] by reaction " + g[vd_firing].get_label();
+      WCS_THROW(err);
+      return false;
+    }
+    updating_species.emplace_back(std::make_pair(vd_updating, stoichio));
+
+    for (const auto vi_affected :
+         boost::make_iterator_range(boost::out_edges(vd_updating, g)))
+    {
+      const auto vd_affected = boost::target(vi_affected, g);
+      if (vd_affected == vd_firing) continue;
+      affected_reactions.insert(vd_affected);
+    }
+  }
+
+  return true;
+}
+
+
+/**
+ * Undo the species updates applied during incomplete reaction processing.
+ * This relies on the list of updates made to species, and revert them.
+ */
+void Sim_Method::undo_species_updates(
+  const Sim_Method::update_list_t& updates) const
+{
+  bool ok = true;
+  const wcs::Network::graph_t& g = m_net_ptr->graph();
+
+  for (const auto& u: updates) {
+    const auto& sv_undo = g[u.first];
+    using s_prop_t = wcs::Species;
+    auto& sp_undo = sv_undo.property<s_prop_t>();
+    if (u.second > static_cast<stoic_t>(0)) {
+      ok &= sp_undo.dec_count(u.second);
+    } else {
+      ok &= sp_undo.inc_count(u.second);
+    }
+    if (!ok) {
+      WCS_THROW("Failed to reverse the species updates");
+    }
+  }
+}
+
+/**
+ * Undo the state update done by the reaction executed.
+ * This is different from `undo_species_updates()` in than this does not
+ * require the list of updates done as it assumes that reaction to undo
+ * has been completed. In addition, this returns which of the species are
+ * restored, and which other reactions are affected. It is rahter similar
+ * to `fire_reaction()` except that it changes the species count in an
+ * opposite way.
+ */
+bool Sim_Method::undo_reaction(
+  const Sim_Method::v_desc_t vd_undo,
+  Sim_Method::update_list_t& reverting_species,
+  Sim_Method::affected_reactions_t& affected_reactions) const
+{
+  using s_prop_t = wcs::Species;
+
+  // Reactions do not change the connectivity, but only change the property
+  // data, which are allocated outside of BGL graph, but only linked to it.
+  const wcs::Network::graph_t& g = m_net_ptr->graph();
+
+  reverting_species.clear();
+  affected_reactions.clear();
+
+  // reactant species
+  for (const auto ei_in :
+       boost::make_iterator_range(boost::in_edges(vd_undo, g)))
+  {
+    const auto vd_reverting = boost::source(ei_in, g);
+    const auto& sv_reverting = g[vd_reverting];
+    if constexpr (wcs::Vertex::_num_vertex_types_  > 3) {
+      // in case that there are other type of vertices than species or reaction
+      if (sv_reverting.get_type() != wcs::Vertex::_species_) continue;
+    }
+
+    auto& sp_reverting = sv_reverting.property<s_prop_t>();
+    const auto stoichio = g[ei_in].get_stoichiometry_ratio();
+    if (stoichio == static_cast<stoic_t>(0)) {
+      continue;
+    }
+    if (!sp_reverting.inc_count(stoichio)) { // State update
+      std::string err = "Unable to undo the decrement of reactant "
+                      + sv_reverting.get_label()
+                      + "[" + std::to_string(sp_reverting.get_count())
+                      + "] for reaction " + g[vd_undo].get_label();
+      WCS_THROW(err);
+      return false;
+    }
+    reverting_species.emplace_back(std::make_pair(vd_reverting, stoichio));
+
+    for (const auto vi_affected :
+         boost::make_iterator_range(boost::out_edges(vd_reverting, g)))
+    {
+      const auto vd_affected = boost::target(vi_affected, g);
+      if (vd_affected == vd_undo) continue;
+      affected_reactions.insert(vd_affected);
+    }
+  }
+
+  // product species
+  for (const auto ei_out :
+       boost::make_iterator_range(boost::out_edges(vd_undo, g)))
+  {
+    const auto vd_reverting = boost::target(ei_out, g);
+    const auto& sv_reverting = g[vd_reverting];
+    if constexpr (wcs::Vertex::_num_vertex_types_  > 3) {
+      // in case that there are other type of vertices than species or reaction
+      if (sv_reverting.get_type() != wcs::Vertex::_species_) continue;
+    }
+
+    auto& sp_reverting = sv_reverting.property<s_prop_t>();
+    const auto stoichio = g[ei_out].get_stoichiometry_ratio();
+    if (stoichio == static_cast<stoic_t>(0)) {
+      continue;
+    }
+    if (!sp_reverting.dec_count(stoichio)) { // State update
+      std::string err = "Unable to undo the production of "
+                      + sv_reverting.get_label()
+                      + "[" + std::to_string(sp_reverting.get_count())
+                      + "] by reaction " + g[vd_undo].get_label();
+      WCS_THROW(err);
+      return false;
+    }
+    reverting_species.emplace_back(std::make_pair(vd_reverting, -stoichio));
+
+    for (const auto vi_affected :
+         boost::make_iterator_range(boost::out_edges(vd_reverting, g)))
+    {
+      const auto vd_affected = boost::target(vi_affected, g);
+      if (vd_affected == vd_undo) continue;
+      affected_reactions.insert(vd_affected);
+    }
+  }
+
+  return true;
+}
 /**@}*/
 } // end of namespace wcs

--- a/src/sim_methods/sim_method.hpp
+++ b/src/sim_methods/sim_method.hpp
@@ -31,6 +31,15 @@ public:
   using sim_time_t = wcs::sim_time_t;
   using reaction_rate_t = wcs::reaction_rate_t;
 
+  /** Type for keeping track of species updates to facilitate undoing
+   *  reaction processing.  */
+  using update_t = std::pair<v_desc_t, stoic_t>;
+  using update_list_t = std::vector<update_t>;
+  /** Type for the list of reactions that share any of the species with the
+   *  firing reaction */
+  using affected_reactions_t = std::set<v_desc_t>;
+
+
   Sim_Method();
   virtual ~Sim_Method();
   virtual void init(std::shared_ptr<wcs::Network>& net_ptr,
@@ -65,6 +74,16 @@ public:
   trace_t& trace();
   /// Allow access to the internal sampler
   samples_t& samples();
+
+  bool fire_reaction(
+       const v_desc_t vd_firing,
+       update_list_t& updating_species,
+       affected_reactions_t& affected_reactions);
+
+  void undo_species_updates(const update_list_t& updates) const;
+  bool undo_reaction(const v_desc_t vd_undo,
+                     update_list_t& reverting_species,
+                     affected_reactions_t& affected_reactions) const;
 
 protected:
 

--- a/src/sim_methods/sim_method.hpp
+++ b/src/sim_methods/sim_method.hpp
@@ -61,12 +61,12 @@ public:
   /// Record the initial state of simulation
   void record_initial_state(const std::shared_ptr<wcs::Network>& net_ptr);
   /// Record the final state of simulation
-  void record_final_state(const sim_time_t dt, const v_desc_t rv);
+  void record_final_state(const v_desc_t rv);
 
   /// Check whether to record the state at current step
   bool check_to_record();
   /// Record the state at current step as needed
-  bool check_to_record(const sim_time_t dt, const v_desc_t rv);
+  bool check_to_record(const v_desc_t rv);
 
   virtual std::pair<sim_iter_t, sim_time_t> run() = 0;
 
@@ -110,8 +110,6 @@ protected:
 
   trace_t m_trace; ///< Tracing record
   samples_t m_samples; ///< Sampling record
-
-  sim_time_t dt_sample; ///< time elapsed since the last sample
 };
 
 /**@}*/

--- a/src/sim_methods/ssa_direct.cpp
+++ b/src/sim_methods/ssa_direct.cpp
@@ -203,6 +203,7 @@ void SSA_Direct::init(std::shared_ptr<wcs::Network>& net_ptr,
   build_propensity_list(); // prepare internal priority queue
 }
 
+
 std::pair<sim_iter_t, sim_time_t> SSA_Direct::run()
 {
   // species to update as a result of the reaction fired
@@ -231,21 +232,23 @@ std::pair<sim_iter_t, sim_time_t> SSA_Direct::run()
       break;
     }
 
+    const sim_time_t m_sim_time_last = m_sim_time;
+    m_sim_time += dt;
+
     if (!Sim_Method::fire_reaction(firing.second,
                                    updating_species,
                                    affected_reactions)) {
+      m_sim_time = m_sim_time_last;
       break;
     }
 
-    is_recorded = check_to_record(dt, firing.second);
+    is_recorded = check_to_record(firing.second);
 
     update_reactions(firing, affected_reactions);
 
-    m_sim_time += dt;
-
     if (m_sim_time >= m_max_time) {
       if (!is_recorded) {
-        record_final_state(dt, firing.second);
+        record_final_state(firing.second);
       }
       break;
     }

--- a/src/sim_methods/ssa_direct.hpp
+++ b/src/sim_methods/ssa_direct.hpp
@@ -25,22 +25,17 @@ public:
   using v_desc_t = Sim_Method::v_desc_t;
   using priority_t = std::pair<reaction_rate_t, v_desc_t>;
   using propensisty_list_t = std::vector<priority_t>;
-  /** Type for the list of reactions that share any of the species with the
-   *  firing reaction */
-  using affected_reactions_t = std::set<v_desc_t>;
 
-  /** Type for keeping track of species updates to facilitate undoing
-   *  reaction processing.  */
-  using update_t = std::pair<v_desc_t, stoic_t>;
-  using update_list_t = std::vector<update_t>;
 
   SSA_Direct();
   ~SSA_Direct() override;
+  /// Initialize propensity list
   void init(std::shared_ptr<wcs::Network>& net_ptr,
             const unsigned max_iter,
             const double max_time,
             const unsigned rng_seed) override;
 
+  /// Main loop of SSA
   std::pair<unsigned, sim_time_t> run() override;
 
   static bool less(const priority_t& v1, const priority_t& v2);
@@ -52,14 +47,8 @@ protected:
   void build_propensity_list();
   priority_t& choose_reaction();
   sim_time_t get_reaction_time();
-  bool fire_reaction(const priority_t& firing,
-                     update_list_t& updating_species,
-                     affected_reactions_t& affected_reactions);
-  void update_reactions(priority_t& firing, const affected_reactions_t& affected);
-  void undo_species_updates(const update_list_t& updates) const;
-  bool undo_reaction(const priority_t& to_undo,
-                     update_list_t& reverting_species,
-                     affected_reactions_t& affected_reactions);
+  void update_reactions(priority_t& firing,
+                        const Sim_Method::affected_reactions_t& affected);
 
 protected:
   /// Cumulative propensity of reactions events

--- a/src/sim_methods/ssa_direct.hpp
+++ b/src/sim_methods/ssa_direct.hpp
@@ -47,7 +47,7 @@ protected:
   void build_propensity_list();
   priority_t& choose_reaction();
   sim_time_t get_reaction_time();
-  void update_reactions(priority_t& firing,
+  void update_reactions(priority_t& fired,
                         const Sim_Method::affected_reactions_t& affected);
 
 protected:

--- a/src/sim_methods/ssa_nrm.cpp
+++ b/src/sim_methods/ssa_nrm.cpp
@@ -17,10 +17,48 @@
 #include <algorithm>
 #include "sim_methods/ssa_nrm.hpp"
 #include "utils/exception.hpp"
+#include "iheap.h"
 
 #if defined(WCS_HAS_CEREAL)
 #include "utils/state_io_cereal.hpp"
 #endif // WCS_HAS_CEREAL
+
+/**
+ * Due to performance, using lambdas instead of std::function or member function.
+ * For each key, the indexer returns a mutable reference to the corresponding
+ * entry in the in-heap index table.
+ * less_reaction compares if the reaction of the first argument is likely to be
+ * less frequent than that of the second one.
+ * less_priority compares if the priority of the first argument is less than
+ * that of the second one/
+ */
+#define lambdas_for_indexed_heap \
+  auto indexer = [this](const v_desc_t& key) -> heap_idx_t& { \
+    auto it = m_idx_table.find(key); \
+    if (it == m_idx_table.end()) { \
+      WCS_THROW("The key (reaction vertex descriptor) does not exist."); \
+    } \
+    return it->second; \
+  }; \
+  \
+  auto less_reaction = [this] \
+    (const v_desc_t& r1, const v_desc_t& r2) -> bool \
+  { \
+    const auto rate1 = m_net_ptr->get_reaction_rate(r1); \
+    const auto rate2 = m_net_ptr->get_reaction_rate(r2); \
+    return (rate1 < rate2) || ((rate1 == rate2) && (r1 > r2)); \
+  }; \
+  \
+  auto less_priority = [this, &less_reaction] \
+       (const priority_t& p1, const priority_t& p2) -> bool \
+  { \
+    return (p1.first > p2.first) || \
+           ((p1.first == p2.first) && less_reaction(p1.second, p2.second)); \
+  };
+  // The previous comparator had (p1.first >= p2.first) only.
+  // When comparing the result against the past commits, This needs to be
+  // consistent
+
 
 namespace wcs {
 /** \addtogroup wcs_reaction_network
@@ -30,14 +68,6 @@ SSA_NRM::SSA_NRM()
 : Sim_Method() {}
 
 SSA_NRM::~SSA_NRM() {}
-
-/**
- * Defines the priority queue ordering by the event time of entries
- * (in ascending order).
- */
-bool SSA_NRM::later(const priority_t& v1, const priority_t& v2) {
-  return (v1.first >= v2.first);
-}
 
 /// Allow access to the internal random number generator
 SSA_NRM::rng_t& SSA_NRM::rgen() {
@@ -53,16 +83,21 @@ SSA_NRM::rng_t& SSA_NRM::rgen() {
  */
 void SSA_NRM::build_heap()
 {
+  lambdas_for_indexed_heap
+
+  // For each reaction, check if the reaction condition is met:
+  // i.e., a sufficient number of reactants
+
+  m_idx_table.clear();
   m_heap.clear();
   m_heap.reserve(m_net_ptr->get_num_reactions()+10);
   constexpr sim_time_t unsigned_max
     = static_cast<sim_time_t>(std::numeric_limits<unsigned>::max());
 
-  // For each reaction, check if the reaction condition is met:
-  // i.e., a sufficient number of reactants
+  const auto reaction_list = m_net_ptr->reaction_list();
+  for (size_t i = 0u; i < reaction_list.size(); ++i) {
+    const auto& vd = reaction_list[i];
 
-  for (const auto& vd : m_net_ptr->reaction_list())
-  {
     if (!m_net_ptr->check_reaction(vd)) {
       m_heap.emplace_back(priority_t(wcs::Network::get_etime_ulimit(), vd));
     } else {
@@ -71,12 +106,19 @@ void SSA_NRM::build_heap()
       const auto t = log(rn)/rate;
       m_heap.emplace_back(priority_t(t, vd));
     }
+    m_idx_table[vd] = static_cast<heap_idx_t>(i); // position in the heap
   }
-  std::make_heap(m_heap.begin(), m_heap.end(), SSA_NRM::later);
+  iheap::make(m_heap.begin(), m_heap.end(), indexer, less_priority);
 }
 
-SSA_NRM::priority_t& SSA_NRM::choose_reaction()
+SSA_NRM::priority_t SSA_NRM::choose_reaction()
 {
+  // lambdas_for_indexed_heap
+  // iheap::pop(m_heap.begin(), m_heap.end(), indexer, less_priority);
+  // auto p = m_heap.back();
+  // m_heap.pop_back();
+  // Instead of removing it and reinserting after the update,
+  // leave it in the heap so as to update in place.
   return m_heap.front();
 }
 
@@ -85,55 +127,67 @@ sim_time_t SSA_NRM::get_reaction_time(const SSA_NRM::priority_t& p)
   return p.first;
 }
 
-void SSA_NRM::reset_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt)
+wcs::sim_time_t SSA_NRM::recompute_reaction_time(const v_desc_t& vd)
 {
   constexpr sim_time_t unsigned_max
     = static_cast<sim_time_t>(std::numeric_limits<unsigned>::max());
 
+  wcs::sim_time_t rt = wcs::Network::get_etime_ulimit();
+
+  // Check if the reason can occur by making sure if the reactant counts are
+  // at least as large as the stoichiometry, and if the product counts can
+  // increase as much as the stoichiometry value.
+  if (!m_net_ptr->check_reaction(vd)) {
+    m_net_ptr->set_reaction_rate(vd, 0.0);
+    return wcs::Network::get_etime_ulimit();
+  }
+
+  // Update the rate of the reaction fired
   const auto new_rate = m_net_ptr->set_reaction_rate(vd);
 
-  if (!m_net_ptr->check_reaction(vd)) {
-    rt = wcs::Network::get_etime_ulimit();
-  } else { // Update the rate of the reaction fired
-    const auto rn = unsigned_max/m_rgen();
-    rt = (new_rate <= static_cast<reaction_rate_t>(0))?
-          wcs::Network::get_etime_ulimit() :
-          log(rn)/new_rate;
+  const auto rn = unsigned_max/m_rgen();
+  rt = (new_rate <= static_cast<reaction_rate_t>(0))?
+        wcs::Network::get_etime_ulimit() :
+        log(rn)/new_rate;
 
-    if (std::isnan(rt)) {
-      rt = wcs::Network::get_etime_ulimit();
-    }
+  if (std::isnan(rt)) {
+    rt = wcs::Network::get_etime_ulimit();
   }
+
+  return rt;
 }
 
-void SSA_NRM::adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt)
+wcs::sim_time_t SSA_NRM::adjust_reaction_time(const v_desc_t& vd,
+                                              wcs::sim_time_t rt)
 {
   using r_prop_t = wcs::Reaction<v_desc_t>;
   constexpr sim_time_t unsigned_max
     = static_cast<sim_time_t>(std::numeric_limits<unsigned>::max());
+
+  if (!m_net_ptr->check_reaction(vd)) {
+    m_net_ptr->set_reaction_rate(vd, 0.0);
+    return wcs::Network::get_etime_ulimit();
+  }
 
   const auto& rv_affected = m_net_ptr->graph()[vd];
   auto& rp_affected = rv_affected.property<r_prop_t>();
   const auto rate_old = rp_affected.get_rate();
   const auto rate_new = m_net_ptr->set_reaction_rate(vd);
 
-  if (!m_net_ptr->check_reaction(vd)) {
+  if (rate_new <= static_cast<reaction_rate_t>(0)) {
     rt = wcs::Network::get_etime_ulimit();
+  } else if (rate_old <= static_cast<reaction_rate_t>(0) ||
+             rt >= wcs::Network::get_etime_ulimit()) {
+    const auto rn = unsigned_max/m_rgen();
+    rt = log(rn)/rate_new;
   } else {
-    if (rate_new <= static_cast<reaction_rate_t>(0)) {
-      rt = wcs::Network::get_etime_ulimit();
-    } else if (rate_old <= static_cast<reaction_rate_t>(0) ||
-               rt >= wcs::Network::get_etime_ulimit()) {
-      const auto rn = unsigned_max/m_rgen();
-      rt = log(rn)/rate_new;
-    } else {
-      rt = rt * rate_old / rate_new;
-    }
-
-    if (std::isnan(rt)) {
-      rt = wcs::Network::get_etime_ulimit();
-    }
+    rt = rt * rate_old / rate_new;
   }
+
+  if (std::isnan(rt)) {
+    rt = wcs::Network::get_etime_ulimit();
+  }
+  return rt;
 }
 
 /**
@@ -142,83 +196,49 @@ void SSA_NRM::adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt)
  * and update the heap. This follows the next reaction method procedure.
  */
 void SSA_NRM::update_reactions(
-       SSA_NRM::priority_t& firing,
+       const SSA_NRM::priority_t& fired,
        const Sim_Method::affected_reactions_t& affected,
        SSA_NRM::reaction_times_t& affected_rtimes)
 {
-  auto t_fired = firing.first;
-
+  const auto& t_fired = fired.first;
+  const auto& r_fired = fired.second;
   affected_rtimes.clear();
-  // Store the reaction time of the the firing reaction before updating
-  const std::pair<v_desc_t, sim_time_t> before_firing(firing.second, t_fired);
 
-  reset_reaction_time(firing.second, firing.first);
+  const auto dt_fired = recompute_reaction_time(r_fired);
 
-  affected_reactions_t affected_reactions(affected);
+  lambdas_for_indexed_heap
 
-  // Update the event time of the rest of affected reactions
-  for (size_t hi = 1u; hi < m_heap.size(); ++ hi) {
-    auto& e = m_heap[hi];
-    const auto& vd = e.second; // BGL vertex descriptor of reaction node
-    auto& et = e.first; // reaction time
-    et -= t_fired;
-    // TODO: need a better facility to locate the affected reaction entry in
-    // the m_heap.
-    auto it_found = affected_reactions.find(vd);
-    if (it_found == affected_reactions.end()) { // not found
-      continue;
-    }
-    // Heap items are unique. No need to find again.
-    affected_reactions.erase(it_found);
+  iheap::update(m_heap.begin(), m_heap.end(), indexer,
+                r_fired, t_fired + dt_fired, less_priority);
+
+  affected_rtimes.emplace_back(std::make_pair(r_fired, t_fired));
+
+  for (auto& r: affected) {
+    const auto t = m_heap[indexer(r)].first; // reaction time
+
+    const auto dt = adjust_reaction_time(r, t - t_fired);
+    iheap::update(m_heap.begin(), m_heap.end(), indexer,
+                  r, t_fired + dt, less_priority);
 
     // Record the reaction time before update
-    affected_rtimes.push_back(std::make_pair(vd, et));
-    adjust_reaction_time(vd, et);
+    affected_rtimes.push_back(std::make_pair(r, t));
   }
-
-  // Add the reaction time of the fired reaction before the update at the end
-  // such that it can easily be used and removed first.
-  affected_rtimes.push_back(before_firing);
-  std::make_heap(m_heap.begin(), m_heap.end(), SSA_NRM::later);
 }
 
 void SSA_NRM::revert_reaction_updates(
        const wcs::sim_time_t dt,
        const SSA_NRM::reaction_times_t& affected)
 {
-  const auto before_firing = affected.back();
+  lambdas_for_indexed_heap
 
-  std::map<v_desc_t, wcs::sim_time_t> affected_reactions;
-  for (const auto& r : affected) {
-    affected_reactions.insert(r);
+  for (auto& r: affected) {
+    // Instead of recomputing the reaction rate, it could have been resotred
+    // from the state saved if it was saved.
+    m_net_ptr->set_reaction_rate(r.first);
+    iheap::update(m_heap.begin(), m_heap.end(), indexer,
+                  r.first, r.second, less_priority);
   }
-
-  // Update the event time of the rest of affected reactions
-  for (size_t hi = 0u; hi < m_heap.size(); ++ hi) {
-    auto& e = m_heap[hi];
-    const auto& vd = e.second;
-    auto& et = e.first;
-
-    // TODO: need a better facility to locate the affected reaction entry in
-    // the m_heap. red-black tree perhaps.
-    auto it_found = affected_reactions.find(vd);
-    if (it_found == affected_reactions.end()) { // not found
-      et += dt;
-    } else {
-      if (vd == before_firing.first) {
-        et = before_firing.second;
-      } else {
-        et = it_found->second + dt; // restore the previous time
-      }
-      m_net_ptr->set_reaction_rate(vd); // recompute reaction rate
-      // Heap items are unique. No need to find again.
-      affected_reactions.erase(it_found);
-    }
-  }
-
-  std::make_heap(m_heap.begin(), m_heap.end(), SSA_NRM::later);
 }
-
 
 void SSA_NRM::init(std::shared_ptr<wcs::Network>& net_ptr,
                    const sim_iter_t max_iter,
@@ -271,7 +291,7 @@ std::pair<sim_iter_t, sim_time_t> SSA_NRM::run()
   // that produce any of the updated species are affected as well. Here, we
   // take the assumption for simplicity. However, if we consider compartments
   // with population/concentration limits, we need to reconsider.
-  affected_reactions_t affected_reactions;
+  Sim_Method::affected_reactions_t affected_reactions;
   // Backup the current reaction times of the affected reactions
   reaction_times_t reaction_times;
 
@@ -279,35 +299,33 @@ std::pair<sim_iter_t, sim_time_t> SSA_NRM::run()
 
   for (; m_cur_iter < m_max_iter; ++ m_cur_iter) {
     if (m_heap.empty()) { // no reaction possible
+      std::cerr << "No reaction exists." << std::endl;
       break;
     }
 
-    auto& firing = choose_reaction();
-    const sim_time_t dt = get_reaction_time(firing);
-    const auto vd_firing = firing.second;
+    auto firing = choose_reaction();
+    const auto vd_firing = firing.second; // reaction vertex descriptor
 
-    if ((dt == std::numeric_limits<sim_time_t>::infinity()) ||
-        (dt >= wcs::Network::get_etime_ulimit())) {
+    if (firing.first >= wcs::Network::get_etime_ulimit()) {
+      std::cerr << "No more reaction can fire." << std::endl;
       break;
     }
-
-    const sim_time_t m_sim_time_last = m_sim_time;
-    m_sim_time += dt;
 
     if (!Sim_Method::fire_reaction(vd_firing,
                                    updating_species,
                                    affected_reactions)) {
-      m_sim_time = m_sim_time_last;
+      std::cerr << "Faile to fire a reaction." << std::endl;
       break;
     }
 
-    is_recorded = check_to_record(firing.second);
-
+    m_sim_time = firing.first;
     update_reactions(firing, affected_reactions, reaction_times);
+
+    is_recorded = check_to_record(vd_firing);
 
     if (m_sim_time >= m_max_time) {
       if (!is_recorded) {
-        record_final_state(firing.second);
+        record_final_state(vd_firing);
       }
       break;
     }

--- a/src/sim_methods/ssa_nrm.cpp
+++ b/src/sim_methods/ssa_nrm.cpp
@@ -291,21 +291,23 @@ std::pair<sim_iter_t, sim_time_t> SSA_NRM::run()
       break;
     }
 
+    const sim_time_t m_sim_time_last = m_sim_time;
+    m_sim_time += dt;
+
     if (!Sim_Method::fire_reaction(vd_firing,
                                    updating_species,
                                    affected_reactions)) {
+      m_sim_time = m_sim_time_last;
       break;
     }
 
-    is_recorded = check_to_record(dt, firing.second);
+    is_recorded = check_to_record(firing.second);
 
     update_reactions(firing, affected_reactions, reaction_times);
 
-    m_sim_time += dt;
-
     if (m_sim_time >= m_max_time) {
       if (!is_recorded) {
-        record_final_state(dt, firing.second);
+        record_final_state(firing.second);
       }
       break;
     }

--- a/src/sim_methods/ssa_nrm.hpp
+++ b/src/sim_methods/ssa_nrm.hpp
@@ -12,6 +12,7 @@
 #define __WCS_SIM_METHODS_SSA_NRM_HPP__
 #include <cmath>
 #include <limits>
+#include <unordered_map>
 #include "sim_methods/sim_method.hpp"
 
 namespace wcs {
@@ -38,22 +39,27 @@ public:
 
   std::pair<sim_iter_t, sim_time_t> run() override;
 
-  static bool later(const priority_t& v1, const priority_t& v2);
   rng_t& rgen();
 
 protected:
   void build_heap();
-  priority_t& choose_reaction();
+  priority_t choose_reaction();
   sim_time_t get_reaction_time(const priority_t& p);
-  void reset_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt);
-  void adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt);
-  void update_reactions(priority_t& firing,
+  wcs::sim_time_t recompute_reaction_time(const v_desc_t& vd);
+  wcs::sim_time_t adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t rt);
+  void update_reactions(const priority_t& fired,
                         const Sim_Method::affected_reactions_t& affected,
                         reaction_times_t& affected_rtimes);
   void revert_reaction_updates(const sim_time_t dt,
                                const reaction_times_t& affected);
 
 protected:
+  /** In-heap index table maintains where in the heap each item can be found.
+      The position in the heap is identified by an index of type idx_t. */
+  using heap_idx_t = int; // the type used in iheap
+  using in_heap_index_table_t = std::unordered_map<v_desc_t, heap_idx_t>;
+
+  in_heap_index_table_t m_idx_table;
   priority_queue_t m_heap;
   rng_t m_rgen;
 };

--- a/src/sim_methods/ssa_nrm.hpp
+++ b/src/sim_methods/ssa_nrm.hpp
@@ -25,16 +25,9 @@ public:
   using priority_t = std::pair<wcs::sim_time_t, v_desc_t>;
   /// Type of heap structure
   using priority_queue_t = std::vector<priority_t>;
-  /** Type for the list of reactions that share any of the species with the
-   *  firing reaction */
-  using affected_reactions_t = std::set<v_desc_t>;
   /// Type of the pair of BGL vertex descriptor for reaction and the its time
   using reaction_times_t = std::vector<std::pair<v_desc_t, wcs::sim_time_t> >;
 
-  /** Type for keeping track of species updates to facilitate undoing
-   *  reaction processing.  */
-  using update_t = std::pair<v_desc_t, stoic_t>;
-  using update_list_t = std::vector<update_t>;
 
   SSA_NRM();
   ~SSA_NRM() override;
@@ -52,20 +45,13 @@ protected:
   void build_heap();
   priority_t& choose_reaction();
   sim_time_t get_reaction_time(const priority_t& p);
-  bool fire_reaction(const v_desc_t vd_firing,
-                     update_list_t& updating_species,
-                     affected_reactions_t& affected_reactions);
   void reset_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt);
   void adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t& rt);
   void update_reactions(priority_t& firing,
-                       const affected_reactions_t& affected,
-                       reaction_times_t& affected_rtimes);
+                        const Sim_Method::affected_reactions_t& affected,
+                        reaction_times_t& affected_rtimes);
   void revert_reaction_updates(const sim_time_t dt,
-                       const reaction_times_t& affected);
-  void undo_species_updates(const update_list_t& updates) const;
-  bool undo_reaction(const v_desc_t vd_undo,
-                     update_list_t& reverting_species,
-                     affected_reactions_t& affected_reactions);
+                               const reaction_times_t& affected);
 
 protected:
   priority_queue_t m_heap;

--- a/src/utils/samples.cpp
+++ b/src/utils/samples.cpp
@@ -202,14 +202,13 @@ std::ostream& Samples::write(std::ostream& os)
   std::vector<r_cnt_t> reactions;
   reactions.resize(m_net_ptr->reaction_list().size(), 0ul);
 
-  sim_time_t sim_time = 0.0; // simulation time
   std::string tmpstr;
 
   build_index_maps();
   write_header(os, reactions.size());
 
   for (const auto& sample : m_samples) {
-    sim_time += std::get<0>(sample); // time of the reaction
+    const auto sim_time = std::get<0>(sample); // time of the reaction
     const s_sample_t& s_sample = std::get<1>(sample);
     const r_sample_t& r_sample = std::get<2>(sample);
     count_species(s_sample, species);

--- a/src/utils/trace.cpp
+++ b/src/utils/trace.cpp
@@ -146,10 +146,8 @@ std::ostream& Trace::write(std::ostream& os)
   trace_t::const_iterator it = m_trace.begin();
   trace_t::const_iterator it_end = m_trace.cend();
 
-  sim_time_t sim_time = 0.0; // simulation time
-
   for (; it != it_end; it++) {
-    sim_time += it->first; // time of the reaction
+    const auto sim_time = it->first; // time of the reaction
     r_desc_t vd_reaction = it->second; // BGL vertex descriptor of the reaction
     count_reaction(vd_reaction);
 

--- a/tests/Birtwhistle/birtwistle.rate.graphml
+++ b/tests/Birtwhistle/birtwistle.rate.graphml
@@ -5004,54 +5004,6 @@ var Nucleus := 1.75e-12;
 m_rate := k28_1*k28_2*k28_3*(Nucleus/Cytoplasm);</data>
         </node>
 
-        <node id="r_vTL27">
-            <data key="v_label">vTL27</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k29_3 := 0.7021;
-var k29_1 := 1.12575;
-var Cytoplasm := 5.25e-12;
-var Nucleus := 1.75e-12;
-var k29_2 := 0.0139149;
-m_rate := k29_1*k29_2*k29_3*(Nucleus/Cytoplasm);</data>
-        </node>
-
-        <node id="r_vTL28">
-            <data key="v_label">vTL28</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k30_2 := 0.000632496;
-var k30_1 := 0.765837;
-var k30_3 := 0.7021;
-var Cytoplasm := 5.25e-12;
-var Nucleus := 1.75e-12;
-m_rate := k30_1*k30_2*k30_3*(Nucleus/Cytoplasm);</data>
-        </node>
-
-        <node id="r_vTL29">
-            <data key="v_label">vTL29</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k31_1 := 0.0351651;
-var k31_2 := 0.00347873;
-var k31_3 := 0.7021;
-var Cytoplasm := 5.25e-12;
-var Nucleus := 1.75e-12;
-m_rate := k31_1*k31_2*k31_3*(Nucleus/Cytoplasm);</data>
-        </node>
-
-        <node id="r_vTL30">
-            <data key="v_label">vTL30</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var Cytoplasm := 5.25e-12;
-var k32_2 := 0.00221374;
-var k32_1 := 1.26575;
-var k32_3 := 0.7021;
-var Nucleus := 1.75e-12;
-m_rate := k32_1*k32_2*k32_3*(Nucleus/Cytoplasm);</data>
-        </node>
-
         <node id="r_vTL31">
             <data key="v_label">vTL31</data>
             <data key="v_type">2</data>
@@ -18618,22 +18570,6 @@ var k1648 := 0.1;
 m_rate := k1648*RasT_CRaf_BRaf;</data>
         </node>
 
-        <node id="r_vP11">
-            <data key="v_label">vP11</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k1649 := 0;
-m_rate := k1649;</data>
-        </node>
-
-        <node id="r_vP12">
-            <data key="v_label">vP12</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k1650 := 0;
-m_rate := k1650;</data>
-        </node>
-
         <node id="r_vP13">
             <data key="v_label">vP13</data>
             <data key="v_type">2</data>
@@ -19561,22 +19497,6 @@ m_rate := k1765*pGSK3b;</data>
 var k1766_1 := 60;
 var k1766_2 := 200;
 m_rate := (k1766_1*bCATENIN*GSK3b^4)/(k1766_2^4+GSK3b^4);</data>
-        </node>
-
-        <node id="r_vP129">
-            <data key="v_label">vP129</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k1767 := 0.1;
-m_rate := k1767;</data>
-        </node>
-
-        <node id="r_vP130">
-            <data key="v_label">vP130</data>
-            <data key="v_type">2</data>
-            <data key="r_rate">
-var k1768 := 1;
-m_rate := k1768;</data>
         </node>
 
         <node id="r_vP131">


### PR DESCRIPTION
Addressing the issue "Convert tracing/sampling to use absolute time" #2 
This will allow cleaner rollback as it eliminates the need to add or subtract delta to obtain absolute time.
Also, address the issue #3 

The comparator used in NRM had (p1.first >= p2.first) only before. Now, a tie-breaking is added.
When comparing the result from this commit against those from the past commits, the comparator needs to be consistent.