### PR TITLE
Handle iheap dependency in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ option(WCS_WITH_SBML "Enable SBML library" OFF)
 
 option(WCS_WITH_EXPRTK "Include ExprTk" OFF)
 
+# Cereal is going to be required.
 option(WCS_WITH_CEREAL "Include Cereal" ON)
 
 option(WCS_WITH_VTUNE
@@ -231,6 +232,10 @@ if (NOT DL_LIBRARY)
   endif (DL_LIBRARY)
 endif ()
 
+include(SetupIHeap)
+
+# Optional dependencies
+
 if (WCS_WITH_SUNDIALS)
   set(WCS_HAS_SUNDIALS FALSE)
   find_package(Sundials MODULE)
@@ -308,6 +313,13 @@ target_include_directories(wcs PUBLIC
 target_include_directories(wcs SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
 # Use the IMPORTED targets when possible.
+
+if (WCS_HAS_IHEAP)
+  add_dependencies(wcs IHEAP-download)
+  target_include_directories(wcs PUBLIC
+    $<BUILD_INTERFACE:${IHEAP_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>)
+endif (WCS_HAS_IHEAP)
 
 if (WCS_HAS_SUNDIALS)
   target_link_libraries(wcs PUBLIC SUNDIALS::SUNDIALS)

--- a/cmake/modules/SetupIHeap.cmake
+++ b/cmake/modules/SetupIHeap.cmake
@@ -1,0 +1,36 @@
+# Download the IHeap library which consists of a single header file only.
+# Set up the variables IHEAP_DIR and IHEAP_HEADER.
+# Create a target for download step IHEAP-download
+
+set(WCS_HAS_IHEAP TRUE)
+set(IHEAP_SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/iheap)
+set(IHEAP_HEADER iheap.hpp)
+
+find_file(IHEAP ${IHEAP_HEADER}
+          HINTS ${IHEAP_SOURCE_DIR}
+                $ENV{IHEAP_ROOT} ${IHEAP_ROOT})
+
+if (IHEAP)
+  message(STATUS "Found iheap: ${IHEAP}")
+  add_custom_target(IHEAP-download)
+  unset(IHEAP_DIR CACHE)
+  get_filename_component(IHEAP_DIR ${IHEAP} DIRECTORY CACHE)
+else ()
+  message(STATUS "iheap will be downloaded.")
+  ExternalProject_Add(IHEAP
+    GIT_REPOSITORY https://github.com/yangle/iheap.git
+    SOURCE_DIR "${IHEAP_SOURCE_DIR}"
+    LOG_DOWNLOAD ON
+    STEP_TARGETS download
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_PATCH ON
+    #PATCH_COMMAND "patch ${IHEAP_SOURCE_DIR}/iheap.h < ${CMAKE_SOURCE_DIR}/external/patch_iheap_h.txt"
+  )
+
+  unset(IHEAP_DIR CACHE)
+  set(IHEAP_DIR ${IHEAP_SOURCE_DIR})
+
+  ExternalProject_Add_StepDependencies(IHEAP build IHEAP-download)
+endif ()

--- a/external/patch_iheap_h.txt
+++ b/external/patch_iheap_h.txt
@@ -1,0 +1,40 @@
+--- iheap.h	2020-08-07 15:36:02.000000000 -0700
++++ iheap.new.h	2020-08-07 10:10:19.000000000 -0700
+@@ -85,7 +85,7 @@
+         typename Compare = std::less<typename std::iterator_traits<RandomIt>::value_type>>
+     void push(RandomIt begin, RandomIt end, Indexer indexer, Compare comp = Compare())
+     {
+-        if (begin >= end)
++        if (begin + 1 >= end)
+             return;
+         indexer((end - 1)->second) = (end - begin) - 1;
+         detail::bubble_up(begin, end, end - 1, indexer, comp);
+@@ -101,8 +101,12 @@
+             return;
+ 
+         auto back = end - 1;
+-        swap(*begin, *back);
+-        swap(indexer(begin->second), indexer(back->second));
++
++        if (back != begin) {
++            swap(*begin, *back);
++            swap(indexer(begin->second), indexer(back->second));
++        }
++
+         indexer(back->second) = -1;
+ 
+         detail::bubble_down(begin, back, begin, indexer, comp);
+@@ -174,8 +178,11 @@
+ 
+         auto old = *it;
+ 
+-        swap(*it, *back);
+-        swap(indexer(it->second), indexer(back->second));
++        if (back != begin) {
++        //https://stackoverflow.com/questions/24444630/is-stdswapx-x-guaranteed-to-leave-x-unchanged
++            swap(*it, *back);
++            swap(indexer(it->second), indexer(back->second));
++        }
+         indexer(back->second) = -1;
+         // works just fine when it == back
+ 


### PR DESCRIPTION
Cmake to install index heap library before building
TODO: apply the patch file in cmake, which is to avoid swapping self