### PR TITLE
refactor forward/backward

### DIFF
--- a/src/sim_methods/sim_method.hpp
+++ b/src/sim_methods/sim_method.hpp
@@ -47,7 +47,7 @@ public:
    *  firing reaction */
   using affected_reactions_t = Sim_State_Change::affected_reactions_t;
 
-  enum result_t {Success, Complete, Failure};
+  enum result_t {Success, Empty, Inactive};
 
   Sim_Method();
   virtual ~Sim_Method();
@@ -69,15 +69,18 @@ public:
 
   /// Record the initial state of simulation
   void record_initial_state(const std::shared_ptr<wcs::Network>& net_ptr);
-  /// Record the final state of simulation
-  void record_final_state(const v_desc_t rv);
 
-  /// Check whether to record the state at current step
-  bool check_to_record();
-  /// Record the state at current step as needed
-  bool check_to_record(const v_desc_t rv);
-  /// Remove the last tracing record
-  void pop_trace();
+  /// Record the state at current step
+  void record(const v_desc_t rv);
+  /// Record the state at time t. This allows tracing/sampling using history.
+  void record(const sim_time_t t, const v_desc_t rv);
+
+ #if defined(WCS_HAS_ROSS)
+  /**
+   * Record as many states as the given number of iterations from the beginning
+   * of the digest list */
+  virtual void record_first_n(const sim_iter_t num) = 0;
+ #endif // defined(WCS_HAS_ROSS)
 
   virtual std::pair<sim_iter_t, sim_time_t> run() = 0;
 
@@ -102,17 +105,11 @@ protected:
   sim_iter_t m_max_iter; ///< Upper bound on simulation iteration
   sim_time_t m_max_time; ///< Upper bound on simulation time
 
-  sim_iter_t m_cur_iter; ///< Current simulation iteration
+  sim_iter_t m_sim_iter; ///< Current simulation iteration
   sim_time_t m_sim_time; ///< Current simulation time
 
   bool m_enable_tracing; ///< Whether to enable tracing
   bool m_enable_sampling; ///< Whether to enable sampling
-
-  sim_iter_t m_sample_iter_interval;
-  sim_time_t m_sample_time_interval;
-
-  sim_iter_t m_next_sample_iter; ///< Next iteration to sample
-  sim_time_t m_next_sample_time; ///< Next time to sample
 
   trace_t m_trace; ///< Tracing record
   samples_t m_samples; ///< Sampling record

--- a/src/sim_methods/ssa_direct.cpp
+++ b/src/sim_methods/ssa_direct.cpp
@@ -8,12 +8,6 @@
  *                                                                            *
  ******************************************************************************/
 
-#if defined(WCS_HAS_CONFIG)
-#include "wcs_config.hpp"
-#else
-#error "no config"
-#endif
-
 #include <algorithm> // upper_bound
 #include <cmath> // log
 #include "sim_methods/ssa_direct.hpp"
@@ -181,7 +175,7 @@ void SSA_Direct::init(std::shared_ptr<wcs::Network>& net_ptr,
   m_max_time = max_time;
   m_max_iter = max_iter;
   m_sim_time = static_cast<sim_time_t>(0);
-  m_cur_iter = static_cast<sim_iter_t>(0u);
+  m_sim_iter = static_cast<sim_iter_t>(0u);
 
   { // initialize the random number generator
     if (rng_seed == 0u) {
@@ -254,46 +248,41 @@ Sim_Method::result_t SSA_Direct::forward(Sim_State_Change& digest)
 {
   if (m_propensity.empty()) { // no reaction possible
     std::cerr << "No reaction exists." << std::endl;
-    return Failure;
+    return Empty;
   }
 
  #if defined(WCS_HAS_ROSS)
   save_rgen_state(digest);
+  digest.m_sim_time = m_sim_time;
  #endif // defined(WCS_HAS_ROSS)
 
+  // Determine the time when a next reaction to occur
   const sim_time_t dt = get_reaction_time();
+
+  if (dt >= wcs::Network::get_etime_ulimit()) {
+    std::cerr << "No more reaction can fire." << std::endl;
+    return Inactive;
+  }
+  m_sim_time += dt; // Scheduling a reaction event
+
+  // Determine the reaction to occur at this time
   auto& firing = choose_reaction();
   // The BGL vertex descriptor of the the reaction being fired
   const auto& rd_fired = digest.m_reaction_fired = firing.second;
 
-  if (dt >= wcs::Network::get_etime_ulimit()) {
-    std::cerr << "No more reaction can fire." << std::endl;
-    return Failure;
-  }
-
- #ifdef NDEBUG
+  // Execute the reaction, updating species counts
   Sim_Method::fire_reaction(digest);
- #else
-  if (!Sim_Method::fire_reaction(digest)) {
-    std::cerr << "Failed to fire a reaction." << std::endl;
-    return Failure;
-  }
- #endif
 
- #if defined(WCS_HAS_ROSS)
-  digest.m_sim_time = m_sim_time;
- #endif // defined(WCS_HAS_ROSS)
-  m_sim_time += dt;
+  // Update the propensities of those reactions fired and affected
   update_reactions(firing, digest.m_reactions_affected, true);
 
-  bool is_recorded = check_to_record(rd_fired);
+ #if !defined(WCS_HAS_ROSS)
+  // With ROSS, tracing and sampling are moved to process at commit time
+  record(rd_fired);
+ #else
+  (void) rd_fired;
+ #endif // defined(WCS_HAS_ROSS)
 
-  if (m_sim_time >= m_max_time) {
-    if (!is_recorded) {
-      record_final_state(rd_fired);
-    }
-    return Complete;
-  }
   return Success;
 }
 
@@ -312,9 +301,24 @@ Sim_Method::result_t SSA_Direct::backward(Sim_State_Change& digest)
   m_sim_time = digest.m_sim_time;
   // Restore the RNG state
   load_rgen_state(digest);
-  // Remove the last trace entry when tracing is on
-  pop_trace();
   return Success;
+}
+
+void SSA_Direct::record_first_n(const sim_iter_t num)
+{
+  if (m_digests.empty()) return;
+  sim_iter_t i = static_cast<sim_iter_t>(0u);
+
+  digest_list_t::iterator it = m_digests.begin();
+  digest_list_t::iterator it_prev = it ++;
+
+  for (; it != m_digests.end(); ++it, ++it_prev) {
+    if (i >= num) break;
+
+    record(it->m_sim_time, it_prev->m_reaction_fired);
+  }
+  record(m_sim_time, it_prev->m_reaction_fired);
+  m_digests.erase(m_digests.begin(), it);
 }
 #endif // defined(WCS_HAS_ROSS)
 
@@ -322,13 +326,38 @@ Sim_Method::result_t SSA_Direct::backward(Sim_State_Change& digest)
 std::pair<sim_iter_t, sim_time_t> SSA_Direct::run()
 {
   Sim_Method::result_t result = Success;
-  Sim_State_Change digest;
 
-  for (; (result == Success) && (m_cur_iter < m_max_iter); ++ m_cur_iter) {
-    result = forward(digest);
+ #if defined(WCS_HAS_ROSS)
+  for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
+    m_digests.emplace_back();
+    result = forward(m_digests.back());
+    if (result != Success) {
+      if (result == Inactive) {
+        //undo_get_reaction_time();
+      }
+      m_digests.pop_back();
+      break;
+    }
+
+    { // rollback test
+      backward(m_digests.back());
+      m_digests.pop_back();
+      m_digests.emplace_back();
+      forward(m_digests.back());
+    }
   }
+  record_first_n(m_sim_iter);
+ #else
+  Sim_State_Change digest;
+  for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
+    result = forward(digest);
+    if (result != Success) {
+      break;
+    }
+  }
+ #endif // defined(WCS_HAS_ROSS)
 
-  return std::make_pair(m_cur_iter, m_sim_time);
+  return std::make_pair(m_sim_iter, m_sim_time);
 }
 
 /**@}*/

--- a/src/sim_methods/ssa_direct.cpp
+++ b/src/sim_methods/ssa_direct.cpp
@@ -244,17 +244,12 @@ void SSA_Direct::load_rgen_state(const Sim_State_Change& digest)
 }
 
 
-Sim_Method::result_t SSA_Direct::forward(Sim_State_Change& digest)
+Sim_Method::result_t SSA_Direct::schedule()
 {
   if (m_propensity.empty()) { // no reaction possible
     std::cerr << "No reaction exists." << std::endl;
     return Empty;
   }
-
- #if defined(WCS_HAS_ROSS)
-  save_rgen_state(digest);
-  digest.m_sim_time = m_sim_time;
- #endif // defined(WCS_HAS_ROSS)
 
   // Determine the time when a next reaction to occur
   const sim_time_t dt = get_reaction_time();
@@ -265,10 +260,21 @@ Sim_Method::result_t SSA_Direct::forward(Sim_State_Change& digest)
   }
   m_sim_time += dt; // Scheduling a reaction event
 
+  return Success;
+}
+
+
+Sim_Method::result_t SSA_Direct::forward(Sim_State_Change& digest)
+{
+ #if defined(WCS_HAS_ROSS)
+  save_rgen_state(digest);
+  digest.m_sim_time = m_sim_time;
+ #endif // defined(WCS_HAS_ROSS)
+
   // Determine the reaction to occur at this time
   auto& firing = choose_reaction();
   // The BGL vertex descriptor of the the reaction being fired
-  const auto& rd_fired = digest.m_reaction_fired = firing.second;
+  digest.m_reaction_fired = firing.second;
 
   // Execute the reaction, updating species counts
   Sim_Method::fire_reaction(digest);
@@ -278,17 +284,15 @@ Sim_Method::result_t SSA_Direct::forward(Sim_State_Change& digest)
 
  #if !defined(WCS_HAS_ROSS)
   // With ROSS, tracing and sampling are moved to process at commit time
-  record(rd_fired);
- #else
-  (void) rd_fired;
+  record(digest.m_reaction_fired);
  #endif // defined(WCS_HAS_ROSS)
 
-  return Success;
+  return schedule();
 }
 
 
 #if defined(WCS_HAS_ROSS)
-Sim_Method::result_t SSA_Direct::backward(Sim_State_Change& digest)
+void SSA_Direct::backward(Sim_State_Change& digest)
 {
   // The BGL vertex descriptor of the the reaction to undo
   const auto& rd_fired = digest.m_reaction_fired;
@@ -301,8 +305,8 @@ Sim_Method::result_t SSA_Direct::backward(Sim_State_Change& digest)
   m_sim_time = digest.m_sim_time;
   // Restore the RNG state
   load_rgen_state(digest);
-  return Success;
 }
+
 
 void SSA_Direct::record_first_n(const sim_iter_t num)
 {
@@ -310,14 +314,12 @@ void SSA_Direct::record_first_n(const sim_iter_t num)
   sim_iter_t i = static_cast<sim_iter_t>(0u);
 
   digest_list_t::iterator it = m_digests.begin();
-  digest_list_t::iterator it_prev = it ++;
 
-  for (; it != m_digests.end(); ++it, ++it_prev) {
+  for (; it != m_digests.end(); ++it) {
     if (i >= num) break;
 
-    record(it->m_sim_time, it_prev->m_reaction_fired);
+    record(it->m_sim_time, it->m_reaction_fired);
   }
-  record(m_sim_time, it_prev->m_reaction_fired);
   m_digests.erase(m_digests.begin(), it);
 }
 #endif // defined(WCS_HAS_ROSS)
@@ -325,26 +327,27 @@ void SSA_Direct::record_first_n(const sim_iter_t num)
 
 std::pair<sim_iter_t, sim_time_t> SSA_Direct::run()
 {
-  Sim_Method::result_t result = Success;
+  Sim_Method::result_t result = schedule();
+  if (result != Success) {
+    WCS_THROW("Not able to schedule any reaction event!");
+  }
 
  #if defined(WCS_HAS_ROSS)
   for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
     m_digests.emplace_back();
     result = forward(m_digests.back());
     if (result != Success) {
-      if (result == Inactive) {
-        //undo_get_reaction_time();
-      }
-      m_digests.pop_back();
       break;
     }
 
+  /*
     { // rollback test
       backward(m_digests.back());
       m_digests.pop_back();
       m_digests.emplace_back();
       forward(m_digests.back());
     }
+  */
   }
   record_first_n(m_sim_iter);
  #else

--- a/src/sim_methods/ssa_direct.hpp
+++ b/src/sim_methods/ssa_direct.hpp
@@ -58,7 +58,7 @@ public:
   Sim_Method::result_t forward(Sim_State_Change& digest);
 
  #if defined(WCS_HAS_ROSS)
-  Sim_Method::result_t backward(Sim_State_Change& digest);
+  void backward(Sim_State_Change& digest);
 
   /** Record as many states as the given number of iterations from the
    *  beginning of the digest list */
@@ -80,6 +80,7 @@ protected:
 
   void save_rgen_state(Sim_State_Change& digest);
   void load_rgen_state(const Sim_State_Change& digest);
+  Sim_Method::result_t schedule();
 
 protected:
   /// Cumulative propensity of reactions events

--- a/src/sim_methods/ssa_direct.hpp
+++ b/src/sim_methods/ssa_direct.hpp
@@ -10,6 +10,13 @@
 
 #ifndef __WCS_SIM_METHODS_SSA_DIRECT_HPP__
 #define __WCS_SIM_METHODS_SSA_DIRECT_HPP__
+
+#if defined(WCS_HAS_CONFIG)
+#include "wcs_config.hpp"
+#else
+#error "no config"
+#endif
+
 #include <cmath>
 #include <limits>
 #include <unordered_map>
@@ -49,8 +56,13 @@ public:
   /// Main loop of SSA
   std::pair<unsigned, sim_time_t> run() override;
   Sim_Method::result_t forward(Sim_State_Change& digest);
+
  #if defined(WCS_HAS_ROSS)
   Sim_Method::result_t backward(Sim_State_Change& digest);
+
+  /** Record as many states as the given number of iterations from the
+   *  beginning of the digest list */
+  void record_first_n(const sim_iter_t num) override;
  #endif // defined(WCS_HAS_ROSS)
 
   static bool less(const priority_t& v1, const priority_t& v2);
@@ -76,6 +88,11 @@ protected:
   rng_t m_rgen_tm; ///< RNG for event times
   /// map from vertex descriptor to propensity
   std::unordered_map<v_desc_t, size_t> m_pindices;
+
+ #if defined(WCS_HAS_ROSS)
+  using digest_list_t = std::list<Sim_State_Change>;
+  digest_list_t m_digests;
+ #endif // defined(WCS_HAS_ROSS)
 };
 
 /**@}*/

--- a/src/sim_methods/ssa_nrm.cpp
+++ b/src/sim_methods/ssa_nrm.cpp
@@ -8,12 +8,6 @@
  *                                                                            *
  ******************************************************************************/
 
-#if defined(WCS_HAS_CONFIG)
-#include "wcs_config.hpp"
-#else
-#error "no config"
-#endif
-
 #include <algorithm>
 #include "sim_methods/ssa_nrm.hpp"
 #include "utils/exception.hpp"
@@ -176,6 +170,7 @@ wcs::sim_time_t SSA_NRM::adjust_reaction_time(const v_desc_t& vd,
     return wcs::Network::get_etime_ulimit();
   } else if (rate_old <= static_cast<reaction_rate_t>(0) ||
              rt >= wcs::Network::get_etime_ulimit()) {
+    // This reaction was previously not enabled, but it is now
     const auto rn = unsigned_max/m_rgen();
     rt = log(rn)/rate_new;
   } else {
@@ -250,7 +245,7 @@ void SSA_NRM::init(std::shared_ptr<wcs::Network>& net_ptr,
   m_max_time = max_time;
   m_max_iter = max_iter;
   m_sim_time = static_cast<sim_time_t>(0);
-  m_cur_iter = 0u;
+  m_sim_iter = static_cast<sim_iter_t>(0u);
 
   { // initialize the random number generator
     if (rng_seed == 0u) {
@@ -312,44 +307,39 @@ Sim_Method::result_t SSA_NRM::forward(Sim_State_Change& digest)
 {
   if (m_heap.empty()) { // no reaction possible
     std::cerr << "No reaction exists." << std::endl;
-    return Failure;
+    return Empty;
   }
 
  #if defined(WCS_HAS_ROSS)
   save_rgen_state(digest);
+  digest.m_sim_time = m_sim_time;
  #endif // defined(WCS_HAS_ROSS)
 
+  // Determine the next reaction and the time when it occurs
   auto firing = choose_reaction();
-  const auto& rd_fired = digest.m_reaction_fired = firing.second;
 
   if (firing.first >= wcs::Network::get_etime_ulimit()) {
     std::cerr << "No more reaction can fire." << std::endl;
-    return Failure;
+    return Inactive;
   }
+  m_sim_time = firing.first; // Scheduling a reaction event
 
- #ifdef NDEBUG
+  // The BGL vertex descriptor of the the reaction being fired
+  const auto& rd_fired = digest.m_reaction_fired = firing.second;
+
+  // Execute the reaction, updating species counts
   Sim_Method::fire_reaction(digest);
- #else
-  if (!Sim_Method::fire_reaction(digest)) {
-    std::cerr << "Faile to fire a reaction." << std::endl;
-    return Failure;
-  }
- #endif
 
- #if defined(WCS_HAS_ROSS)
-  digest.m_sim_time = m_sim_time;
- #endif // defined(WCS_HAS_ROSS)
-  m_sim_time = firing.first;
+  // update the propensities and times of those reactions fired and affected
   update_reactions(firing, digest.m_reactions_affected, digest.m_reaction_times);
 
-  bool is_recorded = check_to_record(rd_fired);
+ #if !defined(WCS_HAS_ROSS)
+  // With ROSS, tracing and sampling are moved to process at commit time
+  record(rd_fired);
+ #else
+  (void) rd_fired;
+ #endif // defined(WCS_HAS_ROSS)
 
-  if (m_sim_time >= m_max_time) {
-    if (!is_recorded) {
-      record_final_state(rd_fired);
-    }
-    return Complete;
-  }
   return Success;
 }
 
@@ -367,9 +357,24 @@ Sim_Method::result_t SSA_NRM::backward(Sim_State_Change& digest)
   m_sim_time = digest.m_sim_time;
   // Restore the RNG state
   load_rgen_state(digest);
-  // Remove the last trace entry when tracing is on
-  pop_trace();
   return Success;
+}
+
+void SSA_NRM::record_first_n(const sim_iter_t num)
+{
+  if (m_digests.empty()) return;
+  sim_iter_t i = static_cast<sim_iter_t>(0u);
+
+  digest_list_t::iterator it = m_digests.begin();
+  digest_list_t::iterator it_prev = it++;
+
+  for (; it != m_digests.end(); ++it, ++it_prev) {
+    if (i >= num) break;
+
+    record(it->m_sim_time, it_prev->m_reaction_fired);
+  }
+  record(m_sim_time, it_prev->m_reaction_fired);
+  m_digests.erase(m_digests.begin(), it);
 }
 #endif // defined(WCS_HAS_ROSS)
 
@@ -377,15 +382,39 @@ Sim_Method::result_t SSA_NRM::backward(Sim_State_Change& digest)
 std::pair<sim_iter_t, sim_time_t> SSA_NRM::run()
 {
   Sim_Method::result_t result = Success;
-  Sim_State_Change digest;
 
-  for (; (result == Success) && (m_cur_iter < m_max_iter); ++ m_cur_iter) {
-    result = forward(digest);
+ #if defined(WCS_HAS_ROSS)
+  for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
+    m_digests.emplace_back();
+    result = forward(m_digests.back());
+    if (result != Success) {
+      if (result == Inactive) {
+        //undo_get_reaction_time();
+      }
+      m_digests.pop_back();
+      break;
+    }
+
+    { // rollback test
+      backward(m_digests.back());
+      m_digests.pop_back();
+      m_digests.emplace_back();
+      forward(m_digests.back());
+    }
   }
+  record_first_n(m_sim_iter);
+ #else
+  Sim_State_Change digest;
+  for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
+    result = forward(digest);
+    if (result != Success) {
+      break;
+    }
+  }
+ #endif // defined(WCS_HAS_ROSS)
 
-  return std::make_pair(m_cur_iter, m_sim_time);
+  return std::make_pair(m_sim_iter, m_sim_time);
 }
-
 
 /**@}*/
 } // end of namespace wcs

--- a/src/sim_methods/ssa_nrm.hpp
+++ b/src/sim_methods/ssa_nrm.hpp
@@ -48,7 +48,7 @@ public:
   Sim_Method::result_t forward(Sim_State_Change& digest);
 
  #if defined(WCS_HAS_ROSS)
-  Sim_Method::result_t backward(Sim_State_Change& digest);
+  void backward(Sim_State_Change& digest);
 
   /** Record as many states as the given number of iterations from the
    *  beginning of the digest list */
@@ -60,7 +60,7 @@ public:
 protected:
   void build_heap();
   priority_t choose_reaction();
-  sim_time_t get_reaction_time(const priority_t& p);
+  sim_time_t get_reaction_time();
   wcs::sim_time_t recompute_reaction_time(const v_desc_t& vd);
   wcs::sim_time_t adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t rt);
   void update_reactions(const priority_t& fired,
@@ -70,6 +70,7 @@ protected:
 
   void save_rgen_state(Sim_State_Change& digest) const;
   void load_rgen_state(const Sim_State_Change& digest);
+  Sim_Method::result_t schedule();
 
 protected:
   /** In-heap index table maintains where in the heap each item can be found.

--- a/src/sim_methods/ssa_nrm.hpp
+++ b/src/sim_methods/ssa_nrm.hpp
@@ -10,6 +10,13 @@
 
 #ifndef __WCS_SIM_METHODS_SSA_NRM_HPP__
 #define __WCS_SIM_METHODS_SSA_NRM_HPP__
+
+#if defined(WCS_HAS_CONFIG)
+#include "wcs_config.hpp"
+#else
+#error "no config"
+#endif
+
 #include <cmath>
 #include <limits>
 #include <unordered_map>
@@ -39,8 +46,13 @@ public:
 
   std::pair<sim_iter_t, sim_time_t> run() override;
   Sim_Method::result_t forward(Sim_State_Change& digest);
+
  #if defined(WCS_HAS_ROSS)
   Sim_Method::result_t backward(Sim_State_Change& digest);
+
+  /** Record as many states as the given number of iterations from the
+   *  beginning of the digest list */
+  void record_first_n(const sim_iter_t num) override;
  #endif // defined(WCS_HAS_ROSS)
 
   rng_t& rgen();
@@ -68,6 +80,11 @@ protected:
   in_heap_index_table_t m_idx_table;
   priority_queue_t m_heap;
   rng_t m_rgen;
+
+ #if defined(WCS_HAS_ROSS)
+  using digest_list_t = std::list<Sim_State_Change>;
+  digest_list_t m_digests;
+ #endif // defined(WCS_HAS_ROSS)
 };
 
 /**@}*/

--- a/src/sim_methods/ssa_sod.cpp
+++ b/src/sim_methods/ssa_sod.cpp
@@ -8,12 +8,6 @@
  *                                                                            *
  ******************************************************************************/
 
-#if defined(WCS_HAS_CONFIG)
-#include "wcs_config.hpp"
-#else
-#error "no config"
-#endif
-
 #include <algorithm> // upper_bound
 #include <cmath> // log
 #include "sim_methods/ssa_sod.hpp"
@@ -176,7 +170,7 @@ void SSA_SOD::init(std::shared_ptr<wcs::Network>& net_ptr,
   m_max_time = max_time;
   m_max_iter = max_iter;
   m_sim_time = static_cast<sim_time_t>(0);
-  m_cur_iter = static_cast<sim_iter_t>(0u);
+  m_sim_iter = static_cast<sim_iter_t>(0u);
 
   { // initialize the random number generator
     if (rng_seed == 0u) {
@@ -249,46 +243,41 @@ Sim_Method::result_t SSA_SOD::forward(Sim_State_Change& digest)
 {
   if (m_propensity.empty()) { // no reaction possible
     std::cerr << "No reaction exists." << std::endl;
-    return Failure;
+    return Empty;
   }
 
  #if defined(WCS_HAS_ROSS)
   save_rgen_state(digest);
+  digest.m_sim_time = m_sim_time;
  #endif // defined(WCS_HAS_ROSS)
 
+  // Determine the time when a next reaction to occur
   const sim_time_t dt = get_reaction_time();
+
+  if (dt >= wcs::Network::get_etime_ulimit()) {
+    std::cerr << "No more reaction can fire." << std::endl;
+    return Inactive;
+  }
+  m_sim_time += dt; // Scheduling a reaction event
+
+  // Determine the reaction to occur at this time
   auto firing = choose_reaction();
   // The BGL vertex descriptor of the the reaction being fired
   const auto& rd_fired = digest.m_reaction_fired = firing.m_rvd;
 
-  if (dt >= wcs::Network::get_etime_ulimit()) {
-    std::cerr << "No more reaction can fire." << std::endl;
-    return Failure;
-  }
-
- #ifdef NDEBUG
+  // Execute the reaction, updating species counts
   Sim_Method::fire_reaction(digest);
- #else
-  if (!Sim_Method::fire_reaction(digest)) {
-    std::cerr << "Faile to fire a reaction." << std::endl;
-    return Failure;
-  }
- #endif
 
- #if defined(WCS_HAS_ROSS)
-  digest.m_sim_time = m_sim_time;
- #endif // defined(WCS_HAS_ROSS)
-  m_sim_time += dt;
+  // Update the propensities of those reactions fired and affected
   update_reactions(rd_fired, digest.m_reactions_affected, true);
 
-  bool is_recorded = check_to_record(rd_fired);
+ #if !defined(WCS_HAS_ROSS)
+  // With ROSS, tracing and sampling are moved to process at commit time
+  record(rd_fired);
+ #else
+  (void) rd_fired;
+ #endif // defined(WCS_HAS_ROSS)
 
-  if (m_sim_time >= m_max_time) {
-    if (!is_recorded) {
-      record_final_state(rd_fired);
-    }
-    return Complete;
-  }
   return Success;
 }
 
@@ -306,9 +295,23 @@ Sim_Method::result_t SSA_SOD::backward(Sim_State_Change& digest)
   m_sim_time = digest.m_sim_time;
   // Restore the RNG state
   load_rgen_state(digest);
-  // Remove the last trace entry when tracing is on
-  pop_trace();
   return Success;
+}
+
+void SSA_SOD::record_first_n(const sim_iter_t num)
+{
+  if (m_digests.empty()) return;
+  sim_iter_t i = static_cast<sim_iter_t>(0u);
+
+  digest_list_t::iterator it = m_digests.begin();
+  digest_list_t::iterator it_prev =  it++;
+  for (; it != m_digests.end(); ++it, ++it_prev) {
+    if (i >= num) break;
+
+    record(it->m_sim_time, it_prev->m_reaction_fired);
+  }
+  record(m_sim_time, it_prev->m_reaction_fired);
+  m_digests.erase(m_digests.begin(), it);
 }
 #endif // defined(WCS_HAS_ROSS)
 
@@ -316,13 +319,38 @@ Sim_Method::result_t SSA_SOD::backward(Sim_State_Change& digest)
 std::pair<sim_iter_t, sim_time_t> SSA_SOD::run()
 {
   Sim_Method::result_t result = Success;
-  Sim_State_Change digest;
 
-  for (; (result == Success) && (m_cur_iter < m_max_iter); ++ m_cur_iter) {
-    result = forward(digest);
+ #if defined(WCS_HAS_ROSS)
+  for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
+    m_digests.emplace_back();
+    result = forward(m_digests.back());
+    if (result != Success) {
+      if (result == Inactive) {
+        //undo_get_reaction_time();
+      }
+      m_digests.pop_back();
+      break;
+    }
+
+    { // rollback test
+      backward(m_digests.back());
+      m_digests.pop_back();
+      m_digests.emplace_back();
+      forward(m_digests.back());
+    }
   }
+  record_first_n(m_sim_iter);
+ #else
+  Sim_State_Change digest;
+  for (; (m_sim_iter < m_max_iter) && (m_sim_time < m_max_time); ++ m_sim_iter) {
+    result = forward(digest);
+    if (result != Success) {
+      break;
+    }
+  }
+ #endif // defined(WCS_HAS_ROSS)
 
-  return std::make_pair(m_cur_iter, m_sim_time);
+  return std::make_pair(m_sim_iter, m_sim_time);
 }
 
 /**@}*/

--- a/src/sim_methods/ssa_sod.hpp
+++ b/src/sim_methods/ssa_sod.hpp
@@ -10,6 +10,13 @@
 
 #ifndef __WCS_SIM_METHODS_SSA_SOD_HPP__
 #define __WCS_SIM_METHODS_SSA_SOD_HPP__
+
+#if defined(WCS_HAS_CONFIG)
+#include "wcs_config.hpp"
+#else
+#error "no config"
+#endif
+
 #include <cmath>
 #include <limits>
 #include <boost/multi_index_container.hpp>
@@ -91,6 +98,10 @@ public:
   Sim_Method::result_t forward(Sim_State_Change& digest);
  #if defined(WCS_HAS_ROSS)
   Sim_Method::result_t backward(Sim_State_Change& digest);
+
+  /** Record as many states as the given number of iterations from the
+   *  beginning of the digest list */
+  void record_first_n(const sim_iter_t num) override;
  #endif // defined(WCS_HAS_ROSS)
 
   rng_t& rgen_e();
@@ -112,6 +123,11 @@ protected:
   propensity_list_t m_propensity;
   rng_t m_rgen_evt; ///< RNG for events
   rng_t m_rgen_tm; ///< RNG for event times
+
+ #if defined(WCS_HAS_ROSS)
+  using digest_list_t = std::list<Sim_State_Change>;
+  digest_list_t m_digests;
+ #endif // defined(WCS_HAS_ROSS)
 };
 
 /**@}*/

--- a/src/sim_methods/ssa_sod.hpp
+++ b/src/sim_methods/ssa_sod.hpp
@@ -97,7 +97,7 @@ public:
   std::pair<unsigned, sim_time_t> run() override;
   Sim_Method::result_t forward(Sim_State_Change& digest);
  #if defined(WCS_HAS_ROSS)
-  Sim_Method::result_t backward(Sim_State_Change& digest);
+  void backward(Sim_State_Change& digest);
 
   /** Record as many states as the given number of iterations from the
    *  beginning of the digest list */
@@ -117,6 +117,7 @@ protected:
 
   void save_rgen_state(Sim_State_Change& digest) const;
   void load_rgen_state(const Sim_State_Change& digest);
+  Sim_Method::result_t schedule();
 
 protected:
   /// Cumulative propensity of reactions events

--- a/src/utils/samples.hpp
+++ b/src/utils/samples.hpp
@@ -42,9 +42,15 @@ public:
   using sample_t = std::tuple<sim_time_t, s_sample_t, r_sample_t>;
   using samples_t = std::list<sample_t>;
 
+  Samples();
+
+  void set_time_interval(const sim_time_t t_interval,
+                         const sim_time_t t_start = static_cast<sim_time_t>(0));
+  void set_iter_interval(const sim_iter_t i_interval,
+                         const sim_iter_t i_start = static_cast<sim_iter_t>(0u));
+
   void record_initial_condition(const std::shared_ptr<wcs::Network>& net_ptr);
-  void record_reaction(const r_desc_t r);
-  void take_sample(const sim_time_t t);
+  void record_reaction(const sim_time_t t, const r_desc_t r);
   std::ostream& write(std::ostream& os);
   void write(const std::string filename);
 
@@ -52,6 +58,7 @@ protected:
   using s_map_t = typename std::unordered_map<s_desc_t, s_diff_t>;
   using r_map_t = typename std::unordered_map<r_desc_t, r_cnt_t>;
 
+  void take_sample();
   void build_index_maps();
   std::ostream& write_header(std::ostream& os,
                              const size_t num_reactions) const;
@@ -90,8 +97,16 @@ protected:
   /// List of samples
   samples_t m_samples;
 
-  /// Number of events
-  sim_iter_t m_num_events;
+  sim_iter_t m_start_iter; ///< Simulation iteration of the first record
+
+  sim_iter_t m_cur_iter; ///< Simulation iteration of the current record
+  sim_time_t m_cur_time; ///< Simulation time of the current record
+
+  sim_iter_t m_sample_iter_interval; ///< Sampling interval in num of iterations
+  sim_time_t m_sample_time_interval; ///< Sampling interval in simulation time
+
+  sim_iter_t m_next_sample_iter; ///< Next iteration to sample
+  sim_time_t m_next_sample_time; ///< Next time to sample
 };
 
 /**@}*/


### PR DESCRIPTION
- Refactor sampling and tracing such that it can run only during commit time without having to worry about rolling back.
- Rearrange SSA iteration such that reaction execution runs first and scheduling runs later per iteration.