### PR TITLE
compilation error fix

### DIFF
--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -24,6 +24,8 @@
 
 #if defined(WCS_HAS_METIS)
 #include "partition/metis_partition.hpp"
+#else
+using idx_t = int;
 #endif // defined(WCS_HAS_METIS)
 
 


### PR DESCRIPTION
fix a compilation error from using the METIS index type idx_t without METIS enabled.