### PR TITLE
Index map

### DIFF
--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -170,6 +170,7 @@ void Network::init()
   }
 
   sort_species();
+  build_index_maps();
 }
 
 /// Overwrite the reaction rate to a given value
@@ -437,5 +438,62 @@ std::string Network::show_reaction_rates() const
   }
   return str;
 }
+
+/**
+ * Build the maps from the vertex descriptor to the index for species and
+ * reactions respectively.
+ */
+void Network::build_index_maps()
+{
+  { // build a map from the vertex descriptor and the index for species
+    m_s_idx_map.clear();
+    m_s_idx_map.reserve(m_species.size());
+
+    v_idx_t sidx = static_cast<v_idx_t>(0u);
+    for (const auto& sd : m_species) {
+      m_s_idx_map[sd] = sidx++;
+    }
+  }
+  { // build a map from the vertex descriptor and the index for reactions
+    m_r_idx_map.clear();
+    m_r_idx_map.reserve(m_reactions.size());
+
+    v_idx_t ridx = static_cast<v_idx_t>(0u);
+    for (const auto& rd : m_reactions) {
+      m_r_idx_map[rd] = ridx++;
+    }
+  }
+}
+
+const Network::map_desc2idx_t& Network::get_reaction_map() const
+{
+  return m_r_idx_map;
+}
+
+const Network::map_desc2idx_t& Network::get_species_map() const
+{
+  return m_s_idx_map;
+}
+
+v_idx_t Network::reaction_d2i(v_desc_t d) const
+{
+  return m_r_idx_map.at(d);
+}
+
+Network::v_desc_t Network::reaction_i2d(v_idx_t i) const
+{
+  return m_reactions.at(i);
+}
+
+v_idx_t Network::species_d2i(v_desc_t d) const
+{
+  return m_s_idx_map.at(d);
+}
+
+Network::v_desc_t Network::species_i2d(v_idx_t i) const
+{
+  return m_species.at(i);
+}
+
 /**@}*/
 } // end of namespace wcs

--- a/src/reaction_network/network.hpp
+++ b/src/reaction_network/network.hpp
@@ -71,8 +71,6 @@ class Network {
   using rdriver_t = Reaction<v_desc_t>::rdriver_t;
   /// Type of the map of species involve in a reaction
   using s_involved_t = std::map<s_label_t, rdriver_t>;
-  /// Reaction descriptor type
-  using r_desc_t = std::pair<v_desc_t, s_involved_t>;
   /// Reaction property type
   using r_prop_t = wcs::Reaction<v_desc_t>;
 
@@ -84,6 +82,9 @@ class Network {
   /** The type of the list of species. This is chosen for the memory efficiency
       than for the lookup performance. */
   using species_list_t  = std::vector<v_desc_t>;
+
+  /// Map a BGL vertex descriptor to the reaction index
+  using map_desc2idx_t = std::unordered_map<v_desc_t, v_idx_t>;
 
  public:
   /// Load an input Graph ML file
@@ -120,9 +121,19 @@ class Network {
   std::string show_species_counts() const;
   std::string show_reaction_rates() const;
 
+  const map_desc2idx_t& get_reaction_map() const;
+  const map_desc2idx_t& get_species_map() const;
+
+  v_idx_t reaction_d2i(v_desc_t d) const;
+  v_desc_t reaction_i2d(v_idx_t i) const;
+  v_idx_t species_d2i(v_desc_t d) const;
+  v_desc_t species_i2d(v_idx_t i) const;
+
+
  protected:
   /// Sort the species list by the label (in lexicogrphical order)
   void sort_species();
+  void build_index_maps();
   void loadGraphML(const std::string graphml_filename);
   void loadSBML(const std::string sbml_filename);
 
@@ -135,6 +146,12 @@ class Network {
 
   /// List of the BGL descriptors of species type vertices
   species_list_t m_species;
+
+  /// Map a BGL vertex descriptor to the reaction index
+  map_desc2idx_t m_r_idx_map;
+
+  /// Map a BGL vertex descriptor to the species index
+  map_desc2idx_t m_s_idx_map;
 
   /**
    * The upper limit of the delay period for an active reaction to fire beyond

--- a/src/sim_methods/sim_method.cpp
+++ b/src/sim_methods/sim_method.cpp
@@ -16,14 +16,18 @@ namespace wcs {
 /** \addtogroup wcs_reaction_network
  *  @{ */
 
-Sim_Method::Sim_Method()
-: m_net_ptr(nullptr),
+Sim_Method::Sim_Method(const std::shared_ptr<wcs::Network>& net_ptr) try
+: m_net_ptr(net_ptr),
   m_max_iter(static_cast<sim_iter_t>(0u)),
   m_max_time(static_cast<sim_time_t>(0)),
   m_sim_iter(static_cast<sim_iter_t>(0u)),
   m_sim_time(static_cast<sim_time_t>(0)),
   m_recording(false)
 {
+  if (!m_net_ptr) {
+    WCS_THROW("Invalid pointer to the reaction network.");
+  }
+
   using directed_category
     = typename boost::graph_traits<wcs::Network::graph_t>::directed_category;
 
@@ -33,6 +37,9 @@ Sim_Method::Sim_Method()
   if constexpr (!is_bidirectional) {
     WCS_THROW("Cannot get species population without in-edges.");
   }
+}
+catch (const std::exception& e) {
+  WCS_THROW("Invalid pointer to the reaction network.");
 }
 
 Sim_Method::~Sim_Method() {}
@@ -46,7 +53,7 @@ void Sim_Method::unset_recording()
 void Sim_Method::initialize_recording(const std::shared_ptr<wcs::Network>& net_ptr)
 { // record initial state of the network
   if (m_recording) {
-    m_trajectory->initialize(m_net_ptr);
+    m_trajectory->initialize();
   }
 }
 

--- a/src/sim_methods/sim_method.hpp
+++ b/src/sim_methods/sim_method.hpp
@@ -43,10 +43,12 @@ public:
 
   enum result_t {Success, Empty, Inactive};
 
-  Sim_Method();
+  Sim_Method(const std::shared_ptr<wcs::Network>& net_ptr);
+  Sim_Method(Sim_Method&& other) = default;
+  Sim_Method& operator=(Sim_Method&& other) = default;
+
   virtual ~Sim_Method();
-  virtual void init(std::shared_ptr<wcs::Network>& net_ptr,
-                    const sim_iter_t max_iter,
+  virtual void init(const sim_iter_t max_iter,
                     const double max_time,
                     const unsigned rng_seed) = 0;
 
@@ -136,7 +138,7 @@ void Sim_Method::set_tracing(const std::string outfile,
                              const unsigned frag_size)
 {
   if (!m_trajectory) {
-    m_trajectory = std::make_unique<T>();
+    m_trajectory = std::make_unique<T>(m_net_ptr);
     if (!m_trajectory) {
       WCS_THROW("Cannot start tracing.");
     }
@@ -151,7 +153,7 @@ void Sim_Method::set_sampling(const sim_time_t time_interval,
                               const unsigned frag_size)
 {
   if (!m_trajectory) {
-    m_trajectory = std::make_unique<S>();
+    m_trajectory = std::make_unique<S>(m_net_ptr);
     if (!m_trajectory) {
       WCS_THROW("Cannot start sampling.");
     }
@@ -167,7 +169,7 @@ void Sim_Method::set_sampling(const sim_iter_t iter_interval,
                               const unsigned frag_size)
 {
   if (!m_trajectory) {
-    m_trajectory = std::make_unique<S>();
+    m_trajectory = std::make_unique<S>(m_net_ptr);
     if (!m_trajectory) {
       WCS_THROW("Cannot start sampling.");
     }

--- a/src/sim_methods/ssa_direct.cpp
+++ b/src/sim_methods/ssa_direct.cpp
@@ -22,8 +22,8 @@ namespace wcs {
 /** \addtogroup wcs_reaction_network
  *  @{ */
 
-SSA_Direct::SSA_Direct()
-: Sim_Method() {}
+SSA_Direct::SSA_Direct(const std::shared_ptr<wcs::Network>& net_ptr)
+: Sim_Method(net_ptr) {}
 
 SSA_Direct::~SSA_Direct() {}
 
@@ -162,16 +162,14 @@ void SSA_Direct::update_reactions(priority_t& fired,
 }
 
 
-void SSA_Direct::init(std::shared_ptr<wcs::Network>& net_ptr,
-                      const sim_iter_t max_iter,
+void SSA_Direct::init(const sim_iter_t max_iter,
                       const double max_time,
                       const unsigned rng_seed)
 {
-  if (!net_ptr) {
+  if (!m_net_ptr) {
     WCS_THROW("Invalid pointer to the reaction network.");
   }
 
-  m_net_ptr = net_ptr;
   m_max_time = max_time;
   m_max_iter = max_iter;
   m_sim_time = static_cast<sim_time_t>(0);

--- a/src/sim_methods/ssa_direct.hpp
+++ b/src/sim_methods/ssa_direct.hpp
@@ -45,11 +45,13 @@ public:
   using propensisty_list_t = std::vector<priority_t>;
 
 
-  SSA_Direct();
+  SSA_Direct(const std::shared_ptr<wcs::Network>& net_ptr);
+  SSA_Direct(SSA_Direct&& other) = default;
+  SSA_Direct& operator=(SSA_Direct&& other) = default;
   ~SSA_Direct() override;
+
   /// Initialize propensity list
-  void init(std::shared_ptr<wcs::Network>& net_ptr,
-            const unsigned max_iter,
+  void init(const unsigned max_iter,
             const double max_time,
             const unsigned rng_seed) override;
 

--- a/src/sim_methods/ssa_nrm.cpp
+++ b/src/sim_methods/ssa_nrm.cpp
@@ -58,8 +58,8 @@ namespace wcs {
 /** \addtogroup wcs_reaction_network
  *  @{ */
 
-SSA_NRM::SSA_NRM()
-: Sim_Method() {}
+SSA_NRM::SSA_NRM(const std::shared_ptr<wcs::Network>& net_ptr)
+: Sim_Method(net_ptr) {}
 
 SSA_NRM::~SSA_NRM() {}
 
@@ -232,16 +232,14 @@ void SSA_NRM::revert_reaction_updates(
   }
 }
 
-void SSA_NRM::init(std::shared_ptr<wcs::Network>& net_ptr,
-                   const sim_iter_t max_iter,
+void SSA_NRM::init(const sim_iter_t max_iter,
                    const sim_time_t max_time,
                    const unsigned rng_seed)
 {
-  if (!net_ptr) {
+  if (!m_net_ptr) {
     WCS_THROW("Invalid pointer to the reaction network.");
   }
 
-  m_net_ptr = net_ptr;
   m_max_time = max_time;
   m_max_iter = max_iter;
   m_sim_time = static_cast<sim_time_t>(0);

--- a/src/sim_methods/ssa_nrm.hpp
+++ b/src/sim_methods/ssa_nrm.hpp
@@ -37,15 +37,17 @@ public:
   using reaction_times_t = Sim_State_Change::reaction_times_t;
 
 
-  SSA_NRM();
+  SSA_NRM(const std::shared_ptr<wcs::Network>& net_ptr);
+  SSA_NRM(SSA_NRM&& other) = default;
+  SSA_NRM& operator=(SSA_NRM&& other) = default;
   ~SSA_NRM() override;
-  void init(std::shared_ptr<wcs::Network>& net_ptr,
-            const sim_iter_t max_iter,
+
+  void init(const sim_iter_t max_iter,
             const sim_time_t max_time,
             const unsigned rng_seed) override;
 
   std::pair<sim_iter_t, sim_time_t> run() override;
-  Sim_Method::result_t forward(Sim_State_Change& digest);
+  SSA_NRM::result_t forward(Sim_State_Change& digest);
 
  #if defined(WCS_HAS_ROSS)
   void backward(Sim_State_Change& digest);
@@ -64,13 +66,13 @@ protected:
   wcs::sim_time_t recompute_reaction_time(const v_desc_t& vd);
   wcs::sim_time_t adjust_reaction_time(const v_desc_t& vd, wcs::sim_time_t rt);
   void update_reactions(const priority_t& fired,
-                        const Sim_Method::affected_reactions_t& affected,
+                        const SSA_NRM::affected_reactions_t& affected,
                         reaction_times_t& affected_rtimes);
   void revert_reaction_updates(const reaction_times_t& affected);
 
   void save_rgen_state(Sim_State_Change& digest) const;
   void load_rgen_state(const Sim_State_Change& digest);
-  Sim_Method::result_t schedule();
+  SSA_NRM::result_t schedule();
 
 protected:
   /** In-heap index table maintains where in the heap each item can be found.

--- a/src/sim_methods/ssa_sod.cpp
+++ b/src/sim_methods/ssa_sod.cpp
@@ -22,8 +22,8 @@ namespace wcs {
 /** \addtogroup wcs_reaction_network
  *  @{ */
 
-SSA_SOD::SSA_SOD()
-: Sim_Method() {}
+SSA_SOD::SSA_SOD(const std::shared_ptr<wcs::Network>& net_ptr)
+: Sim_Method(net_ptr) {}
 
 SSA_SOD::~SSA_SOD() {}
 
@@ -157,16 +157,14 @@ void SSA_SOD::update_reactions(const SSA_SOD::v_desc_t& vd_fired,
 }
 
 
-void SSA_SOD::init(std::shared_ptr<wcs::Network>& net_ptr,
-                      const sim_iter_t max_iter,
-                      const double max_time,
-                      const unsigned rng_seed)
+void SSA_SOD::init(const sim_iter_t max_iter,
+                   const double max_time,
+                   const unsigned rng_seed)
 {
-  if (!net_ptr) {
+  if (!m_net_ptr) {
     WCS_THROW("Invalid pointer to the reaction network.");
   }
 
-  m_net_ptr = net_ptr;
   m_max_time = max_time;
   m_max_iter = max_iter;
   m_sim_time = static_cast<sim_time_t>(0);

--- a/src/sim_methods/ssa_sod.hpp
+++ b/src/sim_methods/ssa_sod.hpp
@@ -85,11 +85,13 @@ public:
   using rvd_idx_t = propensity_list_t::index<tag_rvd>::type;
 
 
-  SSA_SOD();
+  SSA_SOD(const std::shared_ptr<wcs::Network>& net_ptr);
+  SSA_SOD(SSA_SOD&& other) = default;
+  SSA_SOD& operator=(SSA_SOD&& other) = default;
   ~SSA_SOD() override;
+
   /// Initialize propensity list
-  void init(std::shared_ptr<wcs::Network>& net_ptr,
-            const unsigned max_iter,
+  void init(const unsigned max_iter,
             const double max_time,
             const unsigned rng_seed) override;
 

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -226,34 +226,40 @@ int main(int argc, char** argv)
 
   wcs::Sim_Method* ssa = nullptr;
 
-  if (cfg.method == 0) {
-    ssa = new wcs::SSA_Direct;
-    std::cerr << "Direct SSA method." << std::endl;
-  } else if (cfg.method == 1) {
-    std::cerr << "Next Reaction SSA method." << std::endl;
-    ssa = new wcs::SSA_NRM;
-  } else if (cfg.method == 2) {
-    std::cerr << "Sorted optimized direct SSA method." << std::endl;
-    ssa = new wcs::SSA_SOD;
-  } else {
-    std::cerr << "Unknown SSA method (" << cfg.method << ')' << std::endl;
+  try {
+    if (cfg.method == 0) {
+      ssa = new wcs::SSA_Direct(rnet_ptr);
+      std::cerr << "Direct SSA method." << std::endl;
+    } else if (cfg.method == 1) {
+      std::cerr << "Next Reaction SSA method." << std::endl;
+      ssa = new wcs::SSA_NRM(rnet_ptr);
+    } else if (cfg.method == 2) {
+      std::cerr << "Sorted optimized direct SSA method." << std::endl;
+      ssa = new wcs::SSA_SOD(rnet_ptr);
+    } else {
+      std::cerr << "Unknown SSA method (" << cfg.method << ')' << std::endl;
+      return EXIT_FAILURE;
+    }
+  } catch (const std::exception& e) {
+    std::cerr << "Fail to setup SSA method." << std::endl;
     return EXIT_FAILURE;
   }
+
   if (cfg.tracing) {
     ssa->set_tracing<wcs::TraceSSA>(cfg.outfile, cfg.frag_size);
     std::cerr << "Enable tracing" << std::endl;
   } else if (cfg.sampling) {
     if (cfg.iter_interval > 0u) {
       ssa->set_sampling<wcs::SamplesSSA>(cfg.iter_interval, cfg.outfile, cfg.frag_size);
-      std::cerr << "Enable sampling at " << cfg.iter_interval 
+      std::cerr << "Enable sampling at " << cfg.iter_interval
                 << " steps interval" << std::endl;
     } else {
       ssa->set_sampling<wcs::SamplesSSA>(cfg.time_interval, cfg.outfile, cfg.frag_size);
-      std::cerr << "Enable sampling at " << cfg.time_interval 
+      std::cerr << "Enable sampling at " << cfg.time_interval
                 << " secs interval" << std::endl;
     }
   }
-  ssa->init(rnet_ptr, cfg.max_iter, cfg.max_time, cfg.seed);
+  ssa->init(cfg.max_iter, cfg.max_time, cfg.seed);
 
  #ifdef WCS_HAS_VTUNE
   __itt_resume();

--- a/src/utils/samples_ssa.hpp
+++ b/src/utils/samples_ssa.hpp
@@ -13,6 +13,7 @@
 #include <list>
 #include <tuple>
 #include <iostream>
+#include <unordered_map>
 #include "utils/trajectory.hpp"
 
 namespace wcs {
@@ -43,7 +44,12 @@ public:
   using sample_t = std::tuple<sim_time_t, s_sample_t, r_sample_t>;
   using samples_t = std::list<sample_t>;
 
-  SamplesSSA();
+  SamplesSSA(const std::shared_ptr<wcs::Network>& net_ptr);
+  SamplesSSA(const SamplesSSA& other) = default;
+  SamplesSSA(SamplesSSA&& other) = default;
+  SamplesSSA& operator=(const SamplesSSA& other) = default;
+  SamplesSSA& operator=(SamplesSSA&& other) = default;
+
   ~SamplesSSA() override;
 
   void set_time_interval(const sim_time_t t_interval,
@@ -51,6 +57,7 @@ public:
   void set_iter_interval(const sim_iter_t i_interval,
                          const sim_iter_t i_start = static_cast<sim_iter_t>(0u));
 
+  void initialize() override;
   void record_step(const sim_time_t t, const r_desc_t r) override;
   void finalize() override;
 
@@ -58,20 +65,15 @@ protected:
   using s_map_t = typename std::unordered_map<s_desc_t, s_diff_t>;
   using r_map_t = typename std::unordered_map<r_desc_t, r_cnt_t>;
 
-  void build_index_maps() override;
   void take_sample();
   size_t estimate_tmpstr_size() const;
   std::ostream& write_header(std::ostream& os) const override;
-  void count_species(const s_sample_t& ss);
-  void count_reactions(const r_sample_t& ss);
   std::ostream& print_stats(const sim_time_t sim_time,
                             std::string& tmpstr, std::ostream& os) const;
   std::ostream& write(std::ostream& os) override;
   void flush() override;
 
 protected:
-  /// Map a BGL vertex descriptor to the reaction index
-  std::unordered_map<r_desc_t, size_t> m_r_id_map;
   /**
     * Temporary data structure to keep track of the species count differences
     * over the current sampling interval

--- a/src/utils/trace_generic.cpp
+++ b/src/utils/trace_generic.cpp
@@ -30,6 +30,10 @@ namespace wcs {
 /** \addtogroup wcs_utils
  *  @{ */
 
+TraceGeneric::TraceGeneric(const std::shared_ptr<wcs::Network>& net_ptr)
+: Trajectory(net_ptr)
+{}
+
 TraceGeneric::~TraceGeneric()
 {}
 
@@ -42,22 +46,6 @@ void TraceGeneric::record_step(const sim_time_t t, cnt_updates_t&& updates)
     flush();
   }
  #endif // WCS_HAS_CEREAL
-}
-
-/**
- * Build the map from a vertex descriptor to an index of the
- * vector for species respectively.
- */
-void TraceGeneric::build_index_maps()
-{
-  if (m_s_id_map.empty()) {
-    r_idx_t idx = static_cast<r_idx_t>(0u);
-    m_s_id_map.reserve(m_net_ptr->species_list().size());
-
-    for (const auto& sd : m_net_ptr->species_list()) {
-      m_s_id_map[sd] = idx++;
-    }
-  }
 }
 
 void TraceGeneric::finalize()
@@ -168,7 +156,7 @@ std::ostream& TraceGeneric::write(std::ostream& os)
     const auto& updates = it->second; // population updates
 
     for (const auto& u : updates) {
-      species.at(m_s_id_map.at(u.first))
+      species.at(m_s_id_map->at(u.first))
         += static_cast<species_cnt_diff_t>(u.second);
     }
 

--- a/src/utils/trace_generic.hpp
+++ b/src/utils/trace_generic.hpp
@@ -24,12 +24,17 @@ public:
   using tentry_t = typename std::pair<sim_time_t, cnt_updates_t>;
   using trace_t = typename std::list<tentry_t>;
 
+  TraceGeneric(const std::shared_ptr<wcs::Network>& net_ptr);
+  TraceGeneric(const TraceGeneric& other) = default;
+  TraceGeneric(TraceGeneric&& other) = default;
+  TraceGeneric& operator=(const TraceGeneric& other) = default;
+  TraceGeneric& operator=(TraceGeneric&& other) = default;
+
   ~TraceGeneric() override;
   void record_step(const sim_time_t t, cnt_updates_t&& updates) override;
   void finalize() override;
 
 protected:
-  void build_index_maps() override;
   size_t estimate_tmpstr_size() const;
   std::ostream& write_header(std::ostream& os) const override;
   std::ostream& print_stats(const sim_time_t sim_time,

--- a/src/utils/trace_ssa.hpp
+++ b/src/utils/trace_ssa.hpp
@@ -23,14 +23,19 @@ public:
   using tentry_t = typename std::pair<sim_time_t, r_desc_t>;
   using trace_t = typename std::list<tentry_t>;
 
+  TraceSSA(const std::shared_ptr<wcs::Network>& net_ptr);
+  TraceSSA(const TraceSSA& other) = default;
+  TraceSSA(TraceSSA&& other) = default;
+  TraceSSA& operator=(const TraceSSA& other) = default;
+  TraceSSA& operator=(TraceSSA&& other) = default;
+
   ~TraceSSA() override;
+  void initialize() override;
   void record_step(const sim_time_t t, const r_desc_t r) override;
   void finalize() override;
 
 protected:
-  void build_index_maps() override;
   std::ostream& write_header(std::ostream& os) const override;
-  void count_reaction(r_desc_t r);
   size_t estimate_tmpstr_size() const;
   std::ostream& print_stats(const sim_time_t sim_time,
                             const std::string rlabel,
@@ -43,10 +48,6 @@ protected:
   trace_t m_trace;
   /// Show how many times each reaction fires
   std::vector<r_cnt_t> m_reaction_counts;
-  /// Map a BGL vertex descriptor to the reaction index
-  std::unordered_map<r_desc_t, r_idx_t> m_r_id_map;
-  /// Map a reaction index to a BGL vertex descriptor
-  std::vector<r_desc_t> m_r_desc_map;
 };
 
 /**@}*/

--- a/src/utils/trajectory.hpp
+++ b/src/utils/trajectory.hpp
@@ -10,7 +10,6 @@
 
 #ifndef	 __WCS_UTILS_TRAJECTORY_HPP__
 #define	 __WCS_UTILS_TRAJECTORY_HPP__
-#include <unordered_map>
 #include <string>
 #include <iostream>
 #include "sim_methods/update.hpp"
@@ -34,28 +33,31 @@ namespace wcs {
 class Trajectory {
 public:
   /// The type of BGL vertex descriptor for graph_t
-  using v_desc_t = wcs::Network::v_desc_t;
   using s_prop_t = wcs::Species;
-  using r_desc_t = v_desc_t;
-  using r_prop_t = wcs::Reaction<wcs::Network::v_desc_t>;
+  using r_desc_t = wcs::Network::v_desc_t;
+  using r_prop_t = wcs::Network::r_prop_t;
   using r_cnt_t = wcs::species_cnt_t;
-  using r_idx_t = unsigned;
   using frag_id_t = size_t;
+  using map_desc2idx_t = wcs::Network::map_desc2idx_t;
 
-  Trajectory();
+  Trajectory(const std::shared_ptr<wcs::Network>& net_ptr);
+  Trajectory(const Trajectory& other) = default;
+  Trajectory(Trajectory&& other) = default;
+  Trajectory& operator=(const Trajectory& other) = default;
+  Trajectory& operator=(Trajectory&& other) = default;
+
   virtual ~Trajectory();
   void set_outfile(const std::string outfile = "",
                    const frag_size_t frag_size = default_frag_size);
 
-  virtual void initialize(const std::shared_ptr<wcs::Network>& net_ptr);
+  virtual void initialize();
   virtual void record_step(const sim_time_t t, const r_desc_t r);
   virtual void record_step(const sim_time_t t, cnt_updates_t&& updates);
   virtual void record_step(const sim_time_t t, conc_updates_t&& updates);
   virtual void finalize() = 0;
 
 protected:
-  void record_initial_condition(const std::shared_ptr<wcs::Network>& net_ptr);
-  virtual void build_index_maps();
+  void record_initial_condition();
   virtual std::ostream& write_header(std::ostream& os) const = 0;
   virtual std::ostream& write(std::ostream& os) = 0;
   virtual void flush();
@@ -68,8 +70,10 @@ protected:
    *  while the trace refers to it.
    */
   std::shared_ptr<const wcs::Network> m_net_ptr;
+  /// Map a BGL vertex descriptor to the reaction index
+  const map_desc2idx_t* m_r_id_map;
   /// Map a BGL vertex descriptor to the species index
-  std::unordered_map<s_desc_t, size_t> m_s_id_map;
+  const map_desc2idx_t* m_s_id_map;
 
   /// Output file name stem (the part without extention)
   std::string m_outfile_stem;

--- a/src/wcs_types.hpp
+++ b/src/wcs_types.hpp
@@ -27,6 +27,7 @@ using sim_iter_t = unsigned;
 using stoic_t = int;
 using partition_id_t = unsigned;
 using concentration_t = double;
+using v_idx_t = unsigned; ///< vertex index type
 
 constexpr partition_id_t unassigned_partition
   = std::numeric_limits<partition_id_t>::max();


### PR DESCRIPTION
We use map from an BGL vertex descriptor to an integral index for various purposes including logging, and serializing.
Tracing/sampling objects used to manage such maps.
This PR moves that into the network class, which shares the maps with Tracing/sampling via public interfaces.
This removes redundant implementations, and promotes code reuse.