### PR TITLE
Remove the record of extra events occurred past the limit in trajectory

### DIFF
--- a/src/sim_methods/sim_method.cpp
+++ b/src/sim_methods/sim_method.cpp
@@ -103,7 +103,7 @@ void Sim_Method::record(const sim_time_t t,
 
 void Sim_Method::finalize_recording() {
   if (m_recording) {
-    m_trajectory->finalize();
+    m_trajectory->finalize(m_sim_time);
   }
 }
 

--- a/src/utils/samples_ssa.cpp
+++ b/src/utils/samples_ssa.cpp
@@ -153,7 +153,7 @@ void SamplesSSA::take_sample()
  #endif // WCS_HAS_CEREAL
 }
 
-void SamplesSSA::finalize()
+void SamplesSSA::finalize(const sim_time_t t)
 {
   if (m_outfile_stem.empty()) {
     m_num_steps = m_samples.size();

--- a/src/utils/samples_ssa.hpp
+++ b/src/utils/samples_ssa.hpp
@@ -59,7 +59,7 @@ public:
 
   void initialize() override;
   void record_step(const sim_time_t t, const r_desc_t r) override;
-  void finalize() override;
+  void finalize(const sim_time_t t) override;
 
 protected:
   using s_map_t = typename std::unordered_map<s_desc_t, s_diff_t>;

--- a/src/utils/trace_generic.cpp
+++ b/src/utils/trace_generic.cpp
@@ -48,7 +48,7 @@ void TraceGeneric::record_step(const sim_time_t t, cnt_updates_t&& updates)
  #endif // WCS_HAS_CEREAL
 }
 
-void TraceGeneric::finalize()
+void TraceGeneric::finalize(const sim_time_t t)
 {
   if (m_outfile_stem.empty()) {
     m_num_steps = m_trace.size();

--- a/src/utils/trace_generic.hpp
+++ b/src/utils/trace_generic.hpp
@@ -32,7 +32,7 @@ public:
 
   ~TraceGeneric() override;
   void record_step(const sim_time_t t, cnt_updates_t&& updates) override;
-  void finalize() override;
+  void finalize(const sim_time_t t) override;
 
 protected:
   size_t estimate_tmpstr_size() const;

--- a/src/utils/trace_ssa.cpp
+++ b/src/utils/trace_ssa.cpp
@@ -54,8 +54,12 @@ void TraceSSA::initialize()
   m_reaction_counts.resize(m_net_ptr->get_num_reactions());
 }
 
-void TraceSSA::finalize()
+void TraceSSA::finalize(const sim_time_t t)
 {
+  while (!m_trace.empty() && (m_trace.back().first > t)) {
+    m_trace.pop_back();
+  }
+
   if (m_outfile_stem.empty()) {
     m_num_steps = m_trace.size();
     write_header(std::cout);

--- a/src/utils/trace_ssa.hpp
+++ b/src/utils/trace_ssa.hpp
@@ -32,7 +32,7 @@ public:
   ~TraceSSA() override;
   void initialize() override;
   void record_step(const sim_time_t t, const r_desc_t r) override;
-  void finalize() override;
+  void finalize(const sim_time_t t) override;
 
 protected:
   std::ostream& write_header(std::ostream& os) const override;

--- a/src/utils/trajectory.hpp
+++ b/src/utils/trajectory.hpp
@@ -54,7 +54,7 @@ public:
   virtual void record_step(const sim_time_t t, const r_desc_t r);
   virtual void record_step(const sim_time_t t, cnt_updates_t&& updates);
   virtual void record_step(const sim_time_t t, conc_updates_t&& updates);
-  virtual void finalize() = 0;
+  virtual void finalize(const sim_time_t t) = 0;
 
 protected:
   void record_initial_condition();


### PR DESCRIPTION
The extra event only happens with ROSS enabled. This is because we need forward routine record the event whether it succeeds or not such that backward routine can pop exactly on record regardless of whether the forward event was successful or not.