### PR TITLE
Enable a network object to represent a partition

### DIFF
--- a/src/bgl.hpp
+++ b/src/bgl.hpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <boost/config.hpp> // for BOOST_LIKELY
+#include <type_traits>
 
 // To suppress the gcc compiler warning 'maybe-uninitialized'
 // from the boost graph source code.
@@ -37,32 +38,40 @@ namespace wcs {
 template<typename S = void>
 struct adjlist_selector_t {
   using type = ::boost::vecS;
+  using ordered = std::true_type;
 };
 
 template<> struct adjlist_selector_t<::boost::vecS> {
   using type = ::boost::vecS;
+  using ordered = std::true_type;
 };
 
 template<> struct adjlist_selector_t<::boost::listS> {
   using type = ::boost::listS;
+  using ordered = std::true_type;
 };
 
 template<> struct adjlist_selector_t<::boost::setS> {
   using type = ::boost::setS;
+  using ordered = std::true_type;
 };
 
 template<> struct adjlist_selector_t<::boost::multisetS> {
   using type = ::boost::multisetS;
+  using ordered = std::true_type;
 };
 
 template<> struct adjlist_selector_t<::boost::hash_setS> {
   using type = ::boost::hash_setS;
+  using ordered = std::false_type;
 };
 
 #ifndef WCS_VERTEX_LIST_TYPE
 using wcs_vertex_list_t = adjlist_selector_t<>::type;
+using is_vertex_list_ordered = adjlist_selector_t<>::ordered;
 #else
 using wcs_vertex_list_t = adjlist_selector_t<WCS_VERTEX_LIST_TYPE>::type;
+using is_vertex_list_ordered = adjlist_selector_t<WCS_VERTEX_LIST_TYPE>>::ordered;
 #endif
 
 #ifndef WCS_OUT_EDGE_LIST_TYPE

--- a/src/partition/metis_partition.cpp
+++ b/src/partition/metis_partition.cpp
@@ -70,8 +70,8 @@ void Metis_Partition::build_map_from_desc_to_idx()
 
   for (boost::tie(vi, vi_end) = boost::vertices(graph); vi != vi_end; ++vi) {
     const v_desc_t& vertex = *vi;
-    m_idx2vd.emplace(idx, vertex);
-    m_vd2idx.emplace(vertex, idx++);
+    m_idx2vd.emplace_back(vertex);
+    m_vd2idx.emplace(vertex, static_cast<wcs::v_idx_t>(idx++));
     //if constexpr (is_bidirectional) {
     //  m_num_edges += boost::in_degree(vertex, graph);
     //}
@@ -108,13 +108,15 @@ void Metis_Partition::populate_adjacny_list()
       for(const auto ei_in :
           boost::make_iterator_range(boost::in_edges(vertex, graph)))
       {
-        neighbors.push_back(m_vd2idx.at(boost::source(ei_in, graph)));
+        const auto ne = m_vd2idx.at(boost::source(ei_in, graph));
+        neighbors.push_back(static_cast<idx_t>(ne));
       }
 
       for(const auto ei_out :
           boost::make_iterator_range(boost::out_edges(vertex, graph)))
       {
-        neighbors.push_back(m_vd2idx.at(boost::target(ei_out, graph)));
+        const auto ne = m_vd2idx.at(boost::target(ei_out, graph));
+        neighbors.push_back(static_cast<idx_t>(ne));
       }
       std::sort(neighbors.begin(), neighbors.end());
       m_xadj.push_back(m_xadj.back() + neighbors.size());
@@ -134,8 +136,8 @@ void Metis_Partition::populate_adjacny_list()
         const auto n = m_vd2idx.at(boost::target(ei_out, graph));
         std::set<idx_t>& v_neighbors = neighbors_list.at(v);
         std::set<idx_t>& n_neighbors = neighbors_list.at(n);
-        v_neighbors.insert(n);
-        n_neighbors.insert(v);
+        v_neighbors.insert(static_cast<idx_t>(n));
+        n_neighbors.insert(static_cast<idx_t>(v));
       }
     }
 
@@ -360,12 +362,10 @@ void Metis_Partition::print_metis_inputs(
   os << std::endl;
 }
 
-
 void Metis_Partition::print_metis_graph(std::ostream& os) const {
   print_metis_inputs(m_xadj, m_adjncy,
                      m_vwgt, m_vsize, os);
 }
-
 
 void Metis_Partition::print_adjacency(std::ostream& os) const
 {
@@ -386,13 +386,13 @@ void Metis_Partition::print_adjacency(std::ostream& os) const
   os << std::endl;
 }
 
-const std::unordered_map<Network::v_desc_t, idx_t>&
+const Metis_Partition::map_desc2idx_t&
 Metis_Partition::get_map_from_desc_to_idx() const
 {
   return m_vd2idx;
 }
 
-const std::map<idx_t, Network::v_desc_t>&
+const Metis_Partition::map_idx2desc_t&
 Metis_Partition::get_map_from_idx_to_desc() const
 {
   return m_idx2vd;

--- a/src/partition/metis_partition.hpp
+++ b/src/partition/metis_partition.hpp
@@ -38,6 +38,10 @@ class Metis_Partition {
   using directed_category = typename boost::graph_traits<graph_t>::directed_category;
   using v_desc_t = wcs::Network::v_desc_t;
 
+  using map_idx2desc_t = wcs::Network::map_idx2desc_t;
+  using map_desc2idx_t = wcs::Network::map_desc2idx_t;
+
+
   Metis_Partition(const Metis_Params& mp);
 
   /** Return the number of undirected edges that can go into the header of
@@ -70,8 +74,8 @@ class Metis_Partition {
   void print_adjacency(std::ostream& os = std::cout) const;
 
 
-  const std::unordered_map<v_desc_t, idx_t>& get_map_from_desc_to_idx() const;
-  const std::map<idx_t, v_desc_t>& get_map_from_idx_to_desc() const;
+  const map_desc2idx_t& get_map_from_desc_to_idx() const;
+  const map_idx2desc_t& get_map_from_idx_to_desc() const;
 
  protected:
   using v_iter_t = wcs::Network::v_iter_t;
@@ -99,9 +103,9 @@ class Metis_Partition {
   // idx_t is the type defined in metis
 
   /// Map from the BGL vertex descriptor to the vertex index used in Metis
-  std::unordered_map<v_desc_t, idx_t> m_vd2idx;
+  map_desc2idx_t m_vd2idx;
   /// Map from the vertex index used in Metis to the BGL vertex descriptor
-  std::map<idx_t, v_desc_t> m_idx2vd;
+  map_idx2desc_t m_idx2vd;
 
   /// Indices to the adjacency per vertex in the CSR format
   std::vector<idx_t> m_xadj;

--- a/src/reaction_network/vertex.cpp
+++ b/src/reaction_network/vertex.cpp
@@ -31,6 +31,7 @@ std::map<std::string, Vertex::vertex_type> Vertex::str_vt {
 
 Vertex::Vertex()
 : m_type(_undefined_), m_label(""),
+  m_pid(unassigned_partition),
   m_p(nullptr)
 {
   m_typeid = static_cast<int>(m_type);
@@ -40,13 +41,15 @@ Vertex::Vertex(const Vertex& rhs)
 : m_type(rhs.m_type),
   m_typeid(rhs.m_typeid),
   m_label(rhs.m_label),
+  m_pid(rhs.m_pid),
   m_p((!rhs.m_p)? nullptr : rhs.m_p.get()->clone())
 {
 }
 
 Vertex::Vertex(Vertex&& rhs) noexcept
 : m_type(rhs.m_type),
-  m_typeid(rhs.m_typeid)
+  m_typeid(rhs.m_typeid),
+  m_pid(rhs.m_pid)
 {
   if (this != &rhs) {
     m_label = std::move(rhs.m_label);
@@ -62,6 +65,7 @@ Vertex& Vertex::operator=(const Vertex& rhs)
     m_type = rhs.m_type;
     m_typeid = rhs.m_typeid;
     m_label = rhs.m_label;
+    m_pid = rhs.m_pid;
     m_p = (!rhs.m_p)? nullptr : rhs.m_p.get()->clone();
   }
   return *this;
@@ -73,6 +77,7 @@ Vertex& Vertex::operator=(Vertex&& rhs) noexcept
     m_type = rhs.m_type;
     m_typeid = rhs.m_typeid;
     m_label = std::move(rhs.m_label);
+    m_pid = rhs.m_pid;
     m_p = std::move(rhs.m_p);
 
     reset(rhs);
@@ -96,6 +101,7 @@ Vertex* Vertex::clone_impl() const
 void Vertex::reset(Vertex& obj)
 {
    obj.m_label.clear();
+   obj.m_pid = static_cast<partition_id_t>(0);
    obj.m_p = nullptr;
 }
 
@@ -135,6 +141,15 @@ std::string Vertex::get_label() const
   return m_label;
 }
 
+void Vertex::set_partition(const partition_id_t pid)
+{
+  m_pid = pid;
+}
+
+partition_id_t Vertex::get_partition() const
+{
+  return m_pid;
+}
 
 /**@}*/
 } // end of namespace wcs

--- a/src/reaction_network/vertex.hpp
+++ b/src/reaction_network/vertex.hpp
@@ -87,6 +87,8 @@ class Vertex {
   std::string get_type_str() const;
   void set_label(const std::string& lb);
   std::string get_label() const;
+  void set_partition(const partition_id_t pid);
+  partition_id_t get_partition() const;
 
   template <typename P> P& property() const;
   template <typename P> P& checked_property() const;
@@ -103,6 +105,7 @@ class Vertex {
   vertex_type m_type; ///< The vertex type
   int m_typeid; ///< The vertex type in integer form used for GraphML parsing
   std::string m_label; ///< The vertex label
+  partition_id_t m_pid; ///< The id of the partition to which this edge belongs
 
   /**
    * The pointer to the detailed property object, which is polymorphic.
@@ -125,6 +128,7 @@ Vertex::Vertex(const VertexFlat& flat, const G& g)
 : m_type(static_cast<vertex_type>(flat.get_typeid())),
   m_typeid(flat.get_typeid()),
   m_label(flat.get_label()),
+  m_pid(unassigned_partition),
   m_p(nullptr)
 {
   switch(m_type) {
@@ -153,6 +157,7 @@ Vertex::Vertex(const LIBSBML_CPP_NAMESPACE::Species& species, const G& g)
 : m_type(_species_),
   m_typeid(static_cast<int>(_species_)),
   m_label(species.getIdAttribute()),
+  m_pid(unassigned_partition),
   m_p(nullptr)
 {
   m_p = std::unique_ptr<Species>(new Species);
@@ -180,6 +185,7 @@ Vertex::Vertex(
 : m_type(_reaction_),
   m_typeid(static_cast<int>(_reaction_)),
   m_label(reaction.getIdAttribute()),
+  m_pid(unassigned_partition),
   m_p(nullptr)
 {
   using v_desc_t = typename boost::graph_traits<G>::vertex_descriptor;

--- a/src/reaction_network/vertex_flat.cpp
+++ b/src/reaction_network/vertex_flat.cpp
@@ -30,6 +30,7 @@ std::map<std::string, VertexFlat::vertex_type> VertexFlat::str_vt {
 VertexFlat::VertexFlat()
 : m_type(_undefined_),
   m_label(""),
+  m_pid(unassigned_partition),
   m_count(static_cast<s_cnt_t>(0)),
   m_rate(static_cast<r_rate_t>(0)),
   m_rate_formula("")
@@ -40,6 +41,7 @@ VertexFlat::VertexFlat()
 /*
 VertexFlat::VertexFlat(const vertex_type vt, const std::string& lb)
 : m_type(vt), m_label(lb),
+  m_pid(unassigned_partition),
   m_count(static_cast<s_cnt_t>(0)),
   m_rate(static_cast<r_rate_t>(0)),
   m_rate_formula("")
@@ -86,6 +88,16 @@ void VertexFlat::set_label(const std::string& lb)
 std::string VertexFlat::get_label() const
 {
   return m_label;
+}
+
+void VertexFlat::set_partition(const partition_id_t pid)
+{
+  m_pid = pid;
+}
+
+partition_id_t VertexFlat::get_partition() const
+{
+  return m_pid;
 }
 
 bool VertexFlat::inc_count()

--- a/src/reaction_network/vertex_flat.hpp
+++ b/src/reaction_network/vertex_flat.hpp
@@ -43,7 +43,7 @@ namespace wcs {
 
 class VertexFlat {
  public:
-  enum vertex_type { _undefined_, _species_, _reaction_ };
+  enum vertex_type { _undefined_=0, _species_, _reaction_, _num_vertex_types_ };
   static std::map<vertex_type, std::string> vt_str;
   static std::map<std::string, vertex_type> str_vt;
   /// An alternative to the species_cnt_t that is compatible with graphml
@@ -60,6 +60,8 @@ class VertexFlat {
   std::string get_type_str() const;
   void set_label(const std::string& lb);
   std::string get_label() const;
+  void set_partition(const partition_id_t pid);
+  partition_id_t get_partition() const;
 
   bool inc_count();
   bool dec_count();
@@ -77,6 +79,7 @@ class VertexFlat {
   vertex_type m_type;
   int m_typeid;
   std::string m_label; ///< label
+  partition_id_t m_pid; ///< The id of the partition to which this edge belongs
 
   int m_count; ///< copy number of the species
   r_rate_t m_rate; ///< reaction rate

--- a/src/utils/write_graphviz.hpp
+++ b/src/utils/write_graphviz.hpp
@@ -20,14 +20,16 @@ namespace wcs {
  *  @{ */
 
 template <typename G>
-std::ostream& write_graphviz(std::ostream& os, const G& g);
+std::ostream& write_graphviz(std::ostream& os, const G& g,
+                             partition_id_t pid = unassigned_partition);
 
 template <typename G>
-std::ostream& operator<<(std::ostream& os, const G& g);
+std::ostream& operator<<(std::ostream& os, const std::pair<const G&, partition_id_t>& gp);
 
 
 template <typename G>
-bool write_graphviz(const std::string& out_filename, const G& g);
+bool write_graphviz(const std::string& out_filename, const G& g,
+                    partition_id_t pid = unassigned_partition);
 
 /**@}*/
 } // end of namespace wcs

--- a/src/wcs_types.hpp
+++ b/src/wcs_types.hpp
@@ -15,6 +15,16 @@
 #include <memory>  // std::unique_ptr
 #include <limits>  // std::numeric_limits
 
+#if defined(WCS_HAS_CONFIG)
+#include "wcs_config.hpp"
+#else
+#error "no config"
+#endif
+
+#if defined(WCS_HAS_METIS)
+#include <metis.h>
+#endif // defined(WCS_HAS_METIS)
+
 namespace wcs {
 /** \addtogroup wcs_global
  *  @{ */
@@ -25,9 +35,16 @@ using reaction_rate_t = double;
 using sim_time_t = double;
 using sim_iter_t = unsigned;
 using stoic_t = int;
-using partition_id_t = unsigned;
 using concentration_t = double;
 using v_idx_t = unsigned; ///< vertex index type
+
+#if defined(WCS_HAS_METIS)
+// idx_t is Metis integer type, which can be 32-bit or 64-bit long.
+using partition_id_t = idx_t;
+#else
+using partition_id_t = v_idx_t;
+using idx_t = v_idx_t;
+#endif // defined(WCS_HAS_METIS)
 
 constexpr partition_id_t unassigned_partition
   = std::numeric_limits<partition_id_t>::max();


### PR DESCRIPTION
- Enable a network object to represent a partition
- Have each vertex store the id of the partition it belongs to
- Have SSA_NRM only rely on the reactions of the current partition
- Implement utility functions to write partitioned network including the immediate neighbor vertices