### PR TITLE
Count active reactions and report it when running `reaction`

### DIFF
--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -99,6 +99,19 @@ void traverse(const wcs::Network& rnet)
   }
 }
 
+void count_active_reactions(const wcs::Network& rnet)
+{
+  size_t num_active = 0ul;
+  size_t num_total = rnet.reaction_list().size();
+
+  for (const auto r : rnet.reaction_list()) {
+    num_active += static_cast<size_t>(rnet.check_reaction(r));
+  }
+
+  std::cout << "Num active reactions: "
+            << num_active << "/" << num_total << std::endl;
+}
+
 int main(int argc, char** argv)
 {
   int c;
@@ -128,8 +141,10 @@ int main(int argc, char** argv)
   wcs::Network rnet;
 
   rnet.load(fn);
-
   rnet.init();
+
+  count_active_reactions(rnet);
+
   const wcs::Network::graph_t& g = rnet.graph();
 
   if (outfile.empty()) {

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -333,6 +333,13 @@ bool Network::check_reaction(const wcs::Network::v_desc_t r) const
     const auto& sp_reactant = sv_reactant.property<Species>();
     const auto stoichio = m_graph[ei_in].get_stoichiometry_ratio();
     if (!sp_reactant.dec_check(stoichio)) {
+     #if 0
+      using std::operator>>;
+      std::cerr << "reaction " << m_graph[r].get_label()
+                << " has insufficient amount of reactants "
+                << sv_reactant.get_label() << " (" << stoichio << " < "
+                << sp_reactant.get_count() << ")" << std::endl;
+     #endif
       // check if reaction is possible, i.e., decrement is possible
       set_reaction_rate(r, 0.0);
       return false;

--- a/src/sim_methods/ssa_nrm.cpp
+++ b/src/sim_methods/ssa_nrm.cpp
@@ -109,6 +109,7 @@ void SSA_NRM::build_heap()
     }
     m_idx_table[vd] = static_cast<heap_idx_t>(i); // position in the heap
   }
+
   iheap::make(m_heap.begin(), m_heap.end(), indexer, less_priority);
 
   if (m_heap.empty()) {
@@ -119,7 +120,7 @@ void SSA_NRM::build_heap()
     } else {
       errmsg = "There is no reaction!";
     }
-  #if 1
+  #if 0
     WCS_THROW(errmsg);
   #else
     using std::operator<<;
@@ -133,6 +134,7 @@ SSA_NRM::priority_t SSA_NRM::choose_reaction()
 {
  #if 0
   // Enable this block if this condition is not checked in build_heap()
+  // or schedule()
   if (m_heap.empty()) {
     return std::make_pair(wcs::Network::get_etime_ulimit(), v_desc_t{});
   }


### PR DESCRIPTION
Count active reactions and report it when running `reaction`
Reactions are inactive when there is insufficient amount of reactants (less than the stoichiometry).