### PR TITLE
Update the support for Intel compiler 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@
    If both are on, `USE_GCC_LIBCXX` is turned off. When `USE_GCC_LIBCXX`
    is on, `GCC_TOOLCHAIN_VER` can be set accordingly (e.g., "8.1.0").
 
+ + **Guide specific to using the intel compiler on Livermore Computing (LC) platforms**
+   For gcc Interoperability, use `-DGCC_PATH=<path-to-gcc>`. Otherwise,
+   icc picks up the gcc in default path, which may not support c++17.
+
  + **cmake 3.12 or later**
    This requirement mostly comes from the compatibility between the cmake
    module `find_package()`, and the version of boost used. An older version

--- a/cmake/modules/SetupCXX.cmake
+++ b/cmake/modules/SetupCXX.cmake
@@ -98,7 +98,15 @@ endif ()
 
 # Turn off some annoying warnings
 if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-  wcs_check_and_append_flag(CMAKE_CXX_FLAGS -diag-disable=2196)
+  # Bugs with Intel compiler version 19
+  #https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
+  #https://bitbucket.org/berkeleylab/upcxx/issues/286/icc-bug-bogus-warning-use-of-offsetof-with
+  # set(GCC_PATH "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc")
+  if (GCC_PATH)
+    set(GCC_INTEROP "-gcc-name=${GCC_PATH}")
+  endif (GCC_PATH)
+  wcs_check_and_append_flag(CMAKE_CXX_FLAGS -diag-disable=2196 -wd1011 -wd1875 ${GCC_INTEROP})
+
 endif ()
 
 

--- a/src/utils/samples_ssa.hpp
+++ b/src/utils/samples_ssa.hpp
@@ -58,6 +58,7 @@ public:
                          const sim_iter_t i_start = static_cast<sim_iter_t>(0u));
 
   void initialize() override;
+  using Trajectory::record_step;
   void record_step(const sim_time_t t, const r_desc_t r) override;
   void finalize(const sim_time_t t) override;
 

--- a/src/utils/seed.hpp
+++ b/src/utils/seed.hpp
@@ -94,7 +94,8 @@ seed_seq_param_t make_seed_seq_input(const T& v)
                                       T>::type;
   typename std::hash<U> h;
 
-  const auto hv = h(static_cast<const U>(v)); // 64-bit type (i.e. size_t)
+  //const auto hv = h(static_cast<const U>(v)); // 64-bit type (i.e. size_t)
+  const auto hv = h(static_cast<U>(v)); // 64-bit type (i.e. size_t)
 
   // NOTE: This conditional is only needed if seed_seq trims a 64-bit integer
   // input element into a 32-bit one loosing the information before processing

--- a/src/utils/trace_generic.hpp
+++ b/src/utils/trace_generic.hpp
@@ -31,6 +31,7 @@ public:
   TraceGeneric& operator=(TraceGeneric&& other) = default;
 
   ~TraceGeneric() override;
+  using Trajectory::record_step;
   void record_step(const sim_time_t t, cnt_updates_t&& updates) override;
   void finalize(const sim_time_t t) override;
 

--- a/src/utils/trace_ssa.hpp
+++ b/src/utils/trace_ssa.hpp
@@ -31,6 +31,7 @@ public:
 
   ~TraceSSA() override;
   void initialize() override;
+  using Trajectory::record_step;
   void record_step(const sim_time_t t, const r_desc_t r) override;
   void finalize(const sim_time_t t) override;
 


### PR DESCRIPTION
- Allow users to pass the path to gcc for interoperability.
- Suppress compiler warnings