### PR TITLE
Skip gen

### DIFF
--- a/src/generate_cxx_code.cpp
+++ b/src/generate_cxx_code.cpp
@@ -31,12 +31,13 @@ LIBSBML_CPP_NAMESPACE_USE
 
 int main(int argc, char** argv)
 {
-  if (argc != 2) {
-    std::cout << "Usage: " << argv[0] << " filename" << std::endl;
+  if ((argc != 2) && (argc != 3))  {
+    std::cout << "Usage: " << argv[0] << " filename [gen_library(0|1)]" << std::endl;
     return 0;
   }
 
   const char* filename = argv[1];
+  const bool gen_lib = (argc > 2) && (atoi(argv[2]) != 0);
   SBMLReader reader;
   SBMLDocument* document = reader.readSBML(filename);
   const unsigned int num_errors = document->getNumErrors();
@@ -62,9 +63,14 @@ int main(int argc, char** argv)
   using rate_rules_dep = std::unordered_map <std::string, std::set<std::string>>;
   params_map dep_params_f, dep_params_nf;
   rate_rules_dep rate_rules_dep_map;
-  const std::string genfile = wcs::generate_cxx_code::generate_code(*model,
-  dep_params_f, dep_params_nf, rate_rules_dep_map);
-  std::cout << "Generated filename: " << genfile << "\n";
+  wcs::generate_cxx_code code_generator("wcs_generated_code.so", true, false, false);
+  code_generator.generate_code(*model, dep_params_f, dep_params_nf,
+                               rate_rules_dep_map);
+  std::cout << "Generated filename: " << code_generator.get_src_filename() << "\n";
+  if (gen_lib) {
+    const std::string library_file = code_generator.compile_code();
+    std::cout << "library file: " << library_file << std::endl;
+  }
 
   delete document;
   return 0;

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -157,13 +157,14 @@ void Network::loadSBML(const std::string sbml_filename, const bool reuse)
 
   #if !defined(WCS_HAS_EXPRTK)
 
+  const std::string lib_filename = get_libname_from_model(sbml_filename);
+  generate_cxx_code code_generator(lib_filename, reuse);
+
   typename params_map_t::const_iterator pit;
   // dep_params_f = all params in formula expected as input per reaction
   // dep_params_nf = all params not in formula expected as input per reaction
   // rate_rules_dep_map = all rate_rules (params in dep_params_f and dep_params_nf)
   // with their dependent params (transient parameters)
-  // TODO: take the user-defined library filename
-  generate_cxx_code code_generator(std::string(wcs_default_gen_name) + ".so", reuse);
   code_generator.generate_code(*model,
         dep_params_f, dep_params_nf, rate_rules_dep_map);
 

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -41,14 +41,14 @@ using rate_rules_dep_t = std::unordered_map <std::string, std::set<std::string>>
 rate_rules_dep_t rate_rules_dep_map;
 #endif // !defined(WCS_HAS_EXPRTK
 
-void Network::load(const std::string filename)
+void Network::load(const std::string filename, const bool reuse)
 {
   input_filetype fn(filename);
   input_filetype::input_type filetype = fn.detect();
   if (filetype == input_filetype::input_type::_graphml_) {
     loadGraphML(filename);
   } else if (filetype == input_filetype::input_type::_sbml_) {
-    loadSBML(filename);
+    loadSBML(filename, reuse);
   } else if (filetype == input_filetype::input_type::_ioerror_) {
     WCS_THROW("Could not find the requested file.");
     return;
@@ -122,7 +122,7 @@ void Network::print_parameters_of_reactions(
   #endif // !defined(WCS_HAS_EXPRTK
 }
 
-void Network::loadSBML(const std::string sbml_filename)
+void Network::loadSBML(const std::string sbml_filename, const bool reuse)
 {
   #if defined(WCS_HAS_SBML)
 
@@ -158,18 +158,24 @@ void Network::loadSBML(const std::string sbml_filename)
   #if !defined(WCS_HAS_EXPRTK)
 
   typename params_map_t::const_iterator pit;
-  //dep_params_f = all params in formula expected as input per reaction
-  //dep_params_nf = all params not in formula expected as input per reaction
-  //rate_rules_dep_map = all rate_rules (params in dep_params_f and dep_params_nf) with their dependent params (transient parameters)
-  const std::string generated_source = wcs::generate_cxx_code::generate_code(*model,
-  dep_params_f, dep_params_nf, rate_rules_dep_map);
-  const std::string library_file = wcs::generate_cxx_code::compile_code(generated_source);
+  // dep_params_f = all params in formula expected as input per reaction
+  // dep_params_nf = all params not in formula expected as input per reaction
+  // rate_rules_dep_map = all rate_rules (params in dep_params_f and dep_params_nf)
+  // with their dependent params (transient parameters)
+  // TODO: take the user-defined library filename
+  generate_cxx_code code_generator(std::string(wcs_default_gen_name) + ".so", reuse);
+  code_generator.generate_code(*model,
+        dep_params_f, dep_params_nf, rate_rules_dep_map);
+
+  const std::string library_file = code_generator.compile_code();
 
   //using std::operator<<;
   //std::cout << "Generated file: " << generated_source << std::endl;
   // print_parameters_of_reactions(dep_params_f, dep_params_nf, rate_rules_dep_map);
 
-  gfactory.convert_to(*model, m_graph, library_file, dep_params_f, dep_params_nf, rate_rules_dep_map);
+  gfactory.convert_to(*model, m_graph, library_file,
+                      dep_params_f, dep_params_nf,
+                      rate_rules_dep_map);
 
   #else
   gfactory.convert_to(*model, m_graph, "",{},{},{});

--- a/src/reaction_network/network.hpp
+++ b/src/reaction_network/network.hpp
@@ -91,8 +91,16 @@ class Network {
   using map_desc2idx_t = std::unordered_map<v_desc_t, v_idx_t>;
 
  public:
-  /// Load an input Graph ML file
-  void load(const std::string graphml_filename);
+  /** Load an input model file.
+   *  We primarily support SBML as the formats of an input file. However,
+   *  GraphML format is also allowed. The type of a file is automatically
+   *  detected. With SBML, we may set to generate the reaction formula code.
+   *  If that is the case and there already exists a library file generated
+   *  in a previous run, by default, we skip the generation of a new library
+   *  file and reuse the existing library file. Setting the second argument
+   *  `reuse` to false forces regeneration.
+   */
+  void load(const std::string graphml_filename, const bool reuse = true);
   void init();
   void set_reaction_rate(const v_desc_t r, const reaction_rate_t rate) const;
   reaction_rate_t set_reaction_rate(const v_desc_t r) const;
@@ -160,7 +168,7 @@ class Network {
   void sort_species();
   void build_index_maps();
   void loadGraphML(const std::string graphml_filename);
-  void loadSBML(const std::string sbml_filename);
+  void loadSBML(const std::string sbml_filename, const bool reuse = true);
   void print_parameters_of_reactions(
   const params_map_t& dep_params_f,
   const params_map_t& dep_params_nf,

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -83,5 +83,18 @@ bool check_if_file_exists(const std::string filename)
 #endif
 }
 
+/** Return a library name that ends with '.so' with the rest the same as the
+ * model file name */
+std::string get_libname_from_model(const std::string& model_filename)
+{
+  std::string dir, stem, ext;
+  extract_file_component(model_filename, dir, stem, ext);
+
+  if (ext == ".so") {
+    WCS_THROW("Model filename should not have the extension '.so'");
+  }
+  return dir + stem + ".so";
+}
+
 /**@}*/
 } // end of namespace wcs

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -74,5 +74,14 @@ std::string append_to_stem(const std::string path, const std::string str)
   return (parent_dir + stem + str + ext);
 }
 
+bool check_if_file_exists(const std::string filename)
+{
+#if defined(WCS_HAS_STD_FILESYSTEM)
+  return std::filesystem::exists(std::filesystem::path(filename));
+#else
+  return boost::filesystem::exists(boost::filesystem::path(filename));
+#endif
+}
+
 /**@}*/
 } // end of namespace wcs

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -35,6 +35,7 @@ void extract_file_component(const std::string path, std::string& parent_dir,
 /// Returns a new path string that has a stem appended with the given str
 std::string append_to_stem(const std::string path, const std::string str);
 
+bool check_if_file_exists(const std::string filename);
 /**@}*/
 } // end of namespace wcs
 #endif //  __WCS_UTILS_FILE__

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -36,6 +36,9 @@ void extract_file_component(const std::string path, std::string& parent_dir,
 std::string append_to_stem(const std::string path, const std::string str);
 
 bool check_if_file_exists(const std::string filename);
+
+std::string get_libname_from_model(const std::string& model_filename);
+
 /**@}*/
 } // end of namespace wcs
 #endif //  __WCS_UTILS_FILE__

--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1315,7 +1315,7 @@ generate_cxx_code::generate_cxx_code(const std::string& libpath,
 
   if (ext != ".so") {
     m_regen = true;
-    m_lib_filename = dir + (dir.empty()? "./" : "/") + stem + ".so";
+    m_lib_filename = dir + stem + ".so";
     std::cerr << "Generating " + m_lib_filename << std::endl;
   }
 }

--- a/src/utils/graph_factory.hpp
+++ b/src/utils/graph_factory.hpp
@@ -524,16 +524,6 @@ GraphFactory::convert_to(
       }
     }
   }
-  #if !defined(WCS_HAS_EXPRTK)
-  // delete .o and .so files
-  std::string dir;
-  std::string stem;
-  std::string ext;
-  extract_file_component(library_file, dir, stem, ext);
-  std::string lib_filename1 = stem + ".o";
-  std::string system1 = " rm " + library_file + " " + lib_filename1;
-  system(system1.c_str());
-  #endif // !defined(WCS_HAS_EXPRTK)
 }
 #endif // defined(WCS_HAS_SBML)
 

--- a/src/wcs_types.hpp
+++ b/src/wcs_types.hpp
@@ -62,9 +62,8 @@ constexpr size_t cnt_digits = 21ul;
 using frag_size_t = unsigned;
 constexpr frag_size_t default_frag_size = 16384u;
 
-/// The maximum path length of the generated file without the file extension,
-/// used in the generated_cxx_code.cpp
-constexpr size_t wcs_gen_path_max = 26u;
+/// The default name for the generated code file
+constexpr char wcs_default_gen_name[] = "wcs_generated";
 
 /**@}*/
 } // end of namespace wcs


### PR DESCRIPTION
- Converted generate_code() and compile() to non-static member functions
- `class generate_cxx_code` now carries states related to file generation including
   - The output stream open, which is unique_ptr to std::ostream instead of std::ofstream
   - The source file name.
   - The library file name, which is user-given. 
   - A flag to regenerate code or reuse. On by default
   - A flag to remove temporary source file. On by default.
   - A flag to save compilation error log. Off by default.
 - Added a constructor to set those flags as well as the desired library file name.
   - If the library file name does not ends with `.so`, it replaces the extension.
   - If the user-provided library file name is null string, the default name is used
 - source file name is made with the suffix `.cc`
   - This guarantees the uniqueness of the full filename.
   - The prefix is based on the user-provided library name
 - When it is set to reuse, the generate_code() performs the usual dependency analysis.
   - However, the output is directed to a null stream
   - If the library files to reuse does not exist, it generates a new one regardless.
 - Check errors with system()
 - `src/generate_cxx_code` now takes an option to generate library file.
 TODO: In a following PR, add option to specify new directory for library file. Currently, the entire path of the model file name is used as the prefix of the library file name. Sometimes, the model file can be read-only storage, or user just does not want them to be in the same directory.