### PR TITLE
relocate the routine to print the network content

### DIFF
--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -55,59 +55,6 @@ void print_usage(const std::string exec, int code)
   exit(code);
 }
 
-using graph_t  = boost::adjacency_list<
-    boost::vecS,
-    boost::vecS,
-    boost::bidirectionalS,
-    wcs::Vertex,
-    wcs::Edge,
-    boost::no_property,
-    boost::vecS>;
-
-
-void traverse(const wcs::Network& rnet)
-{
-  const wcs::Network::graph_t& g = rnet.graph();
-  using r_prop_t = wcs::Reaction<wcs::Network::v_desc_t>;
-  using s_prop_t = wcs::Species;
-
-  std::cout << "Species:";
-  for(const auto& vd : rnet.species_list()) {
-    const auto& sv = g[vd];
-    const auto& sp = sv.property<s_prop_t>();
-    std::cout << ' ' << sv.get_label() << '[' << sp.get_count() << ']';
-  }
-
-  std::cout << "\n\nReactions:\n";
-  for(const auto& vd : rnet.reaction_list()) {
-    using directed_category
-      = typename boost::graph_traits<wcs::Network::graph_t>::directed_category;
-    constexpr bool is_bidirectional
-      = std::is_same<directed_category, boost::bidirectional_tag>::value;
-
-    const auto& rv = g[vd];
-    const auto& rp = rv.property<r_prop_t>();
-    std::cout << "  " << rv.get_label()
-              << " with rate constant " << rp.get_rate_constant() << " :";
-
-    std::cout << " produces";
-    for(const auto vi_out : boost::make_iterator_range(boost::out_edges(vd, g))) {
-      std::cout << ' ' << g[boost::target(vi_out, g)].get_label();
-    }
-
-    if constexpr (is_bidirectional) {
-      std::cout << " from a set of reactants";
-      for(const auto vi_in : boost::make_iterator_range(boost::in_edges(vd, g))) {
-        const auto& sv = g[boost::source(vi_in, g)];
-        const auto& sp = sv.property<s_prop_t>();
-        std::cout << ' ' << sv.get_label() << " [" << sp.get_count() << "]";
-      }
-    }
-
-    std::cout << std::endl << "    by the rate " << rp.get_rate()
-              << " <= {" << rp.get_rate_formula() << "}" << std::endl;
-  }
-}
 
 void count_active_reactions(const wcs::Network& rnet)
 {
@@ -180,7 +127,7 @@ int main(int argc, char** argv)
     rc = -1;
   }
 
-  traverse(rnet);
+  rnet.print();
  #endif // !WCS_PERF_PROF
 
   if (num_iter > 0u) {

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -224,7 +224,6 @@ void Network::init()
       }
       #endif // !defined(WCS_HAS_EXPRTK)
 
-      int reaction_in=0, reaction_out=0; 
       if constexpr (is_bidirectional) {
         for(const auto ei_in :
             boost::make_iterator_range(boost::in_edges(reaction, m_graph))) {
@@ -241,7 +240,6 @@ void Network::init()
           const auto st = m_graph[ei_in].get_stoichiometry_ratio();
           involved_species.insert(std::make_pair(m_graph[reactant].get_label(),
                                                  std::make_pair(reactant, st)));
-          reaction_in = reaction_in + 1;   
         }
       }
 
@@ -250,7 +248,6 @@ void Network::init()
         v_desc_t product = boost::target(ei_out, m_graph);
         products.insert(std::make_pair(m_graph[product].get_label(),
                                        std::make_pair(product, 1)));
-        reaction_out = reaction_out + 1; 
       }
 
       m_reactions.emplace_back(reaction);
@@ -304,7 +301,7 @@ void Network::init()
       set_reaction_rate(*vi);
     }
   }
-  
+
   sort_species();
   build_index_maps();
 
@@ -463,7 +460,8 @@ sim_time_t Network::get_etime_ulimit()
 
 /**
  * Check if the condition for reaction is satisfied such as whether a
- * sufficient number of reactants exist.
+ * sufficient number of reactants exist. If not, the reaction rate is
+ * set to zero.
  */
 bool Network::check_reaction(const wcs::Network::v_desc_t r) const
 {
@@ -725,6 +723,7 @@ void Network::print() const
     const auto& sp = sv.property<s_prop_t>();
     std::cout << ' ' << sv.get_label() << '[' << sp.get_count() << ']';
   }
+  size_t num_inactive = 0ul;
 
   std::cout << "\n\nReactions:\n";
   for(const auto& vd : reaction_list()) {
@@ -738,10 +737,22 @@ void Network::print() const
     std::cout << "  " << rv.get_label()
               << " with rate constant " << rp.get_rate_constant() << " :";
 
+    bool inactive = false;
+
     std::cout << " produces";
     for(const auto vi_out : boost::make_iterator_range(boost::out_edges(vd, m_graph))) {
-      std::cout << ' ' << m_graph[boost::target(vi_out, m_graph)].get_label();
-    }
+      const auto& sv = m_graph[boost::target(vi_out, m_graph)];
+      const auto& sp = sv.property<s_prop_t>();
+      std::cout << ' ' << sv.get_label();
+      if (!inactive) {
+        if constexpr (wcs::Vertex::_num_vertex_types_  > 3) {
+          // in case of a vertex type other than the species or the reaction
+          if (sv.get_type() != wcs::Vertex::_species_) continue;
+        }
+        const auto stoichio = m_graph[vi_out].get_stoichiometry_ratio();
+        inactive |= sp.inc_check(stoichio);
+      }
+    } // end of for loop over out-edges
 
     if constexpr (is_bidirectional) {
       std::cout << " from a set of reactants";
@@ -749,12 +760,29 @@ void Network::print() const
         const auto& sv = m_graph[boost::source(vi_in, m_graph)];
         const auto& sp = sv.property<s_prop_t>();
         std::cout << ' ' << sv.get_label() << " [" << sp.get_count() << "]";
-      }
+
+        if (!inactive) {
+          if constexpr (wcs::Vertex::_num_vertex_types_  > 3) {
+            // in case of a vertex type other than the species or the reaction
+            if (sv.get_type() != wcs::Vertex::_species_) continue;
+          }
+          const auto stoichio = m_graph[vi_in].get_stoichiometry_ratio();
+          inactive |= sp.dec_check(stoichio);
+        }
+      } // end of for loop over in-edges
+    } // end of is_bidirectional
+
+    num_inactive += static_cast<size_t>(inactive);
+    if (inactive) {
+      m_graph[vd].property<r_prop_t>().set_rate(0.0);
     }
 
     std::cout << std::endl << "    by the rate " << rp.get_rate()
               << " <= {" << rp.get_rate_formula() << "}" << std::endl;
-  }
+  } // end of for loop over the reaction list
+
+  std::cout << "Num inactive reactions: "
+            << num_inactive << "/" << reaction_list().size() << std::endl;
 }
 
 /**@}*/

--- a/src/reaction_network/network.hpp
+++ b/src/reaction_network/network.hpp
@@ -155,6 +155,8 @@ class Network {
   /// Return the id of this partition
   partition_id_t get_partition_id() const;
 
+  void print() const;
+
  protected:
   /// Sort the species list by the label (in lexicogrphical order)
   void sort_species();
@@ -162,9 +164,9 @@ class Network {
   void loadGraphML(const std::string graphml_filename);
   void loadSBML(const std::string sbml_filename);
   void print_parameters_of_reactions(
-  const params_map_t& dep_params_f,
-  const params_map_t& dep_params_nf,
-  const rate_rules_dep_t& rate_rules_dep_map);
+         const params_map_t& dep_params_f,
+         const params_map_t& dep_params_nf,
+         const rate_rules_dep_t& rate_rules_dep_map);
 
  protected:
   /// The BGL graph to represent a reaction network

--- a/src/sim_methods/sim_method.cpp
+++ b/src/sim_methods/sim_method.cpp
@@ -156,6 +156,7 @@ bool Sim_Method::fire_reaction(Sim_State_Change& digest)
       std::string err = "Not enough reactants of " + sv_updating.get_label()
                       + "[" + std::to_string(sp_updating.get_count())
                       + "] for reaction " + g[rd_firing].get_label();
+      //m_net_ptr->print();
       WCS_THROW(err);
       return false;
     }


### PR DESCRIPTION
Relocated the routine to print the network content from `src/reaction.cpp` to `src/reaction_network/network.cpp`.
It is not an official member function of `Network` class, such that it can be called somewhere else as well.