### PR TITLE
Fix the bug in termination condition check with NRM

### DIFF
--- a/src/ssa-cfg.hpp
+++ b/src/ssa-cfg.hpp
@@ -43,7 +43,7 @@ static const struct option longopts[] = {
 struct Config {
   Config()
   : seed(0u), max_iter(10u),
-    max_time(wcs::Network::get_etime_ulimit()),
+    max_time(wcs::max_sim_time),
     method(1),
     tracing(false),
     sampling(false),

--- a/src/wcs_types.hpp
+++ b/src/wcs_types.hpp
@@ -46,6 +46,9 @@ using partition_id_t = v_idx_t;
 using idx_t = v_idx_t;
 #endif // defined(WCS_HAS_METIS)
 
+constexpr sim_time_t max_sim_time
+  = std::numeric_limits<sim_time_t>::max() - 1;
+
 constexpr partition_id_t unassigned_partition
   = std::numeric_limits<partition_id_t>::max();
 


### PR DESCRIPTION
There was a bug in comparing the next event time is beyond the limit.