### PR TITLE
add a utility function to create a directorty

### DIFF
--- a/src/bgl.hpp
+++ b/src/bgl.hpp
@@ -71,7 +71,7 @@ using wcs_vertex_list_t = adjlist_selector_t<>::type;
 using is_vertex_list_ordered = adjlist_selector_t<>::ordered;
 #else
 using wcs_vertex_list_t = adjlist_selector_t<WCS_VERTEX_LIST_TYPE>::type;
-using is_vertex_list_ordered = adjlist_selector_t<WCS_VERTEX_LIST_TYPE>>::ordered;
+using is_vertex_list_ordered = adjlist_selector_t<WCS_VERTEX_LIST_TYPE>::ordered;
 #endif
 
 #ifndef WCS_OUT_EDGE_LIST_TYPE

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -11,6 +11,7 @@
 #ifndef  __WCS_UTILS_FILE__
 #define  __WCS_UTILS_FILE__
 #include <string>
+#include <sys/stat.h> // mode_t
 
 #if defined(WCS_HAS_CONFIG)
 #include "wcs_config.hpp"
@@ -40,6 +41,8 @@ bool check_if_file_exists(const std::string filename);
 std::string get_libname_from_model(const std::string& model_filename);
 
 std::string get_default_outname_from_model(const std::string& model_filename);
+
+int mkdir_as_needed (const std::string& path, const mode_t m = 0700);
 
 /**@}*/
 } // end of namespace wcs


### PR DESCRIPTION
Create a directory `path` with the given access permission `m`.

- It is the same as the POSIX mkdir() except that it does not return as failure if the directory to create already exists with the same access permission.
- However, the access group name is not checked.
- The default mode of creation is 0700.