### PR TITLE
Allow specifying different temporary directory in JIT

### DIFF
--- a/src/generate_cxx_code.cpp
+++ b/src/generate_cxx_code.cpp
@@ -32,10 +32,10 @@ LIBSBML_CPP_NAMESPACE_USE
 
 int main(int argc, char** argv)
 {
-  if ((argc < 2) || (argc > 5))  {
+  if ((argc < 2) || (argc > 6))  {
     std::cout << "Usage: " << argv[0]
               << " model_filename [gen_library(0|1)"
-              << " [compilation_error_log(0|1) [chunk_size]]]" << std::endl;
+              << " [compilation_error_log(0|1) [chunk_size [tmpdir]]]]" << std::endl;
     return EXIT_SUCCESS;
   }
 
@@ -43,6 +43,7 @@ int main(int argc, char** argv)
   const bool gen_lib = (argc > 2) && (atoi(argv[2]) != 0);
   const bool show_error = (argc > 3) && (atoi(argv[3]) != 0);
   const unsigned int chunk_size = ((argc > 4)? atoi(argv[4]) : 1000u);
+  const std::string tmp_dir = ((argc > 5)? argv[5] : "/tmp");
   SBMLReader reader;
   SBMLDocument* document = reader.readSBML(model_filename);
   const unsigned int num_errors = document->getNumErrors();
@@ -68,8 +69,8 @@ int main(int argc, char** argv)
   std::cout << "chunk size: " << chunk_size << std::endl;
 
   const std::string lib_filename = wcs::get_libname_from_model(model_filename);
-  wcs::generate_cxx_code code_generator(lib_filename,
-                                        true, show_error, false, chunk_size);
+  wcs::generate_cxx_code code_generator(lib_filename, true, show_error, false,
+                                        tmp_dir, chunk_size);
 
   using params_map = std::unordered_map <std::string, std::vector<std::string>>;
   using rate_rules_dep = std::unordered_map <std::string, std::set<std::string>>;

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -170,8 +170,8 @@ void Network::loadSBML(const std::string sbml_filename, const bool reuse)
 
   const std::string library_file = code_generator.compile_code();
 
-  //using std::operator<<;
-  //std::cout << "Generated file: " << generated_source << std::endl;
+  using std::operator<<;
+  std::cerr << "Constructing a graph from SBML ..." << std::endl;
   // print_parameters_of_reactions(dep_params_f, dep_params_nf, rate_rules_dep_map);
 
   gfactory.convert_to(*model, m_graph, library_file,

--- a/src/reaction_network/network.cpp
+++ b/src/reaction_network/network.cpp
@@ -171,7 +171,7 @@ void Network::loadSBML(const std::string sbml_filename, const bool reuse)
   const std::string library_file = code_generator.compile_code();
 
   using std::operator<<;
-  std::cerr << "Constructing a graph from SBML ..." << std::endl;
+  std::cerr << "Constructing a graph from the SBML model ..." << std::endl;
   // print_parameters_of_reactions(dep_params_f, dep_params_nf, rate_rules_dep_map);
 
   gfactory.convert_to(*model, m_graph, library_file,
@@ -187,6 +187,7 @@ void Network::loadSBML(const std::string sbml_filename, const bool reuse)
   #else
   WCS_THROW("SBML is not enabled.");
   #endif // defined(WCS_HAS_SBML)
+  std::cerr << "The SBML model has been loaded into a graph!" << std::endl;
 
 }
 

--- a/src/ssa_partition.cpp
+++ b/src/ssa_partition.cpp
@@ -461,6 +461,7 @@ bool setup_partition(const std::string& input_model,
     partitioner.print_adjacency(std::cout);
   }
 
+  std::cerr << "Start partitioning ..." << std::endl;
   idx_t objval; /// Total comm volume or edge-cut of the solution
   bool ret = partitioner.run(parts, objval);
   if (!ret) return false;
@@ -490,6 +491,7 @@ bool setup_partition(const std::string& input_model,
     pinfo.scan(mp.m_verbose);
     pinfo.report();
   }
+  std::cerr << "Partitioning complete!" << std::endl;
   return true;
 }
 

--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1726,6 +1726,14 @@ void generate_cxx_code::generate_code(
   params_map_t& dep_params_nf,
   rate_rules_dep_t& rate_rules_dep_map)
 {
+ #if defined(_OPENMP)
+  #pragma omp master
+ #endif // defined(_OPENMP)
+  {
+    std::string msg = std::string("Analyzing dependencies ")
+                    + (m_regen? " and generating code for JIT ..." : "...");
+    std::cerr << msg << std::endl;
+  }
 
   // A map for initial_assignments
   initial_assignments_t sinitial_assignments;
@@ -1795,7 +1803,7 @@ void generate_cxx_code::generate_code(
                          rate_rules_dep_map);
 
   // define functions for events
-  if ( ev_assign.size() > 0ul) {
+  if (ev_assign.size() > 0ul) {
     os_common_impl << "\n//Define functions for events\n";
     generate_cxx_code::print_event_functions(model, os_common_impl, ev_assign,
                                              wcs_all_const, wcs_all_var);
@@ -1953,6 +1961,12 @@ std::string generate_cxx_code::gen_makefile()
 
 std::string generate_cxx_code::compile_code()
 {
+ #if defined(_OPENMP)
+  #pragma omp master
+ #endif // defined(_OPENMP)
+  {
+    std::cerr << "JIT compiling ..." << std::endl;
+  }
   int ret = EXIT_SUCCESS;
 
   if (!m_regen) {

--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1403,7 +1403,7 @@ void generate_cxx_code::create_ostream(src_file_t& ofile, size_t suffix_size)
   std::string& src_name = ofile.first;
   std::unique_ptr<std::ostream>& os_ptr = ofile.second;
 
-  char tmp_filename[PATH_MAX];
+  char tmp_filename[PATH_MAX + 1] = {'\0'};
   strncpy(tmp_filename, src_name.c_str(), PATH_MAX);
 
   int fd = mkostemps(tmp_filename, static_cast<int>(suffix_size),

--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1346,24 +1346,28 @@ generate_cxx_code::generate_cxx_code(const std::string& libpath,
      }
   }
 
-  if (((m_tmp_dir.size() == 1u) && (m_tmp_dir[0] == '/')) ||
-      m_tmp_dir.empty())
+ #if defined(_OPENMP)
+  #pragma omp master
+ #endif // defined(_OPENMP)
   {
-   #if defined(_OPENMP)
-    #pragma omp master
-   #endif // defined(_OPENMP)
+    if (((m_tmp_dir.size() == 1u) && (m_tmp_dir[0] == '/')) ||
+        m_tmp_dir.empty())
     {
       std::cerr << "Creating files into the current directory" << std::endl;
-    }
-    m_tmp_dir = ".";
-  } else {
-    if (m_regen) {
-      int ret = mkdir_as_needed(m_tmp_dir);
-      if (ret != 0) {
-        WCS_THROW("Terminating after failed to create a directory.");
+      m_tmp_dir = ".";
+    } else if (m_tmp_dir != "/tmp") {
+      if (m_regen) {
+        int ret = mkdir_as_needed(m_tmp_dir);
+        if (ret != 0) {
+          WCS_THROW("Terminating after failed to create a directory.");
+        }
       }
     }
   }
+ #if defined(_OPENMP)
+  #pragma omp barrier
+ #endif // defined(_OPENMP)
+
   if (m_tmp_dir[0] != '/') {
      char canonical[PATH_MAX] = {'\0'};
      realpath("./", canonical);
@@ -1382,9 +1386,6 @@ generate_cxx_code::generate_cxx_code(const std::string& libpath,
               + " the machine code for reaction rate formula ("
               + m_lib_filename + ")" << std::endl;
   }
- #if defined(_OPENMP)
-  #pragma omp barrier
- #endif // defined(_OPENMP)
 }
 
 //https://stackoverflow.com/questions/8243743/is-there-a-null-stdostream-implementation-in-c-or-libraries

--- a/src/utils/generate_cxx_code.hpp
+++ b/src/utils/generate_cxx_code.hpp
@@ -51,6 +51,7 @@ class generate_cxx_code {
                     bool regen = false,
                     bool save_log = false,
                     bool cleanup = true,
+                    const std::string& tmp_dir = "tmp_jit",
                     unsigned int chunk_size = 1000u);
 
   void generate_code(
@@ -186,6 +187,7 @@ class generate_cxx_code {
    bool m_regen; ///< Whether to regenerate the library
    bool m_save_log; ///< Whether to save compilation log
    bool m_cleanup; ///< Whether to remove the temporary source file generated
+   std::string m_tmp_dir;
 
    /// The number of reactions to group into a translation unit for compilation
    unsigned int m_chunk;


### PR DESCRIPTION
- Currently, all the temporary files, e.g., source code files, object files and makefile, are written into `/tmp`.
- This has a performance advantage over writing into a file system. However, the capacity is limited as tmpfs resides in memory.
- `generate_cxx_code` constructor now takes another argument to set the path of the temporary directory.
- By default, it is `./tmp_jit`.
- `src/generate_cxx_code.cpp` takes a command line argument to choose the temporary directory. With SSA simulation, we currently do not have an option to specify it from the command line.
- TODO: protobuf-based options for JIT.
- This PR is based on PR #88 
- The major changes include the member variable `m_tmp_dir` to `generate_cxx_code` class, and set it via the constructor
