### PR TITLE
Fix dep analysis with omp

### DIFF
--- a/src/reaction_network/network.hpp
+++ b/src/reaction_network/network.hpp
@@ -174,10 +174,10 @@ class Network {
   void build_index_maps();
   void loadGraphML(const std::string graphml_filename);
   void loadSBML(const std::string sbml_filename, const bool reuse = true);
-  void print_parameters_of_reactions(
-         const params_map_t& dep_params_f,
-         const params_map_t& dep_params_nf,
-         const rate_rules_dep_t& rate_rules_dep_map);
+  static void print_parameters_of_reactions(
+             const params_map_t& dep_params_f,
+             const params_map_t& dep_params_nf,
+             const rate_rules_dep_t& rate_rules_dep_map);
 
  protected:
   /// The BGL graph to represent a reaction network
@@ -208,6 +208,18 @@ class Network {
   reaction_list_t m_my_reactions;
   /// List of species that belong to this partition
   species_list_t m_my_species;
+
+ #if !defined(WCS_HAS_EXPRTK)
+  /// all params in formula expected as input per reaction
+  params_map_t m_dep_params_f;
+  /// all params not in formula expected as input per reaction
+  params_map_t m_dep_params_nf;
+  /**
+   *  all rate_rules (params in dep_params_f and dep_params_nf) with their
+   *  dependent params (transient parameters)
+   */
+  rate_rules_dep_t m_rate_rules_dep_map;
+ #endif // !defined(WCS_HAS_EXPRTK
 };
 
 /**@}*/

--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1201,9 +1201,9 @@ void generate_cxx_code::print_reaction_rates(
 
     // put input parameters into maps
     dep_params_f.insert(std::make_pair(reaction.getIdAttribute(),
-                                                 par_names));
+                                       par_names));
     dep_params_nf.insert(std::make_pair(reaction.getIdAttribute(),
-                                                 par_names_nf));
+                                        par_names_nf));
 
     //genfile << "printf(\" and expected  %u \\n\", " << par_index << ");\n";
     /*genfile << "  printf(\"Expected in generated code: \");\n";
@@ -1290,9 +1290,7 @@ void generate_cxx_code::print_reaction_rates(
     //        << reaction.getIdAttribute() << ");\n";
     genfile << "  return " << reaction.getIdAttribute() << ";\n";
     genfile << "}\n\n";
-
   }
-
 }
 
 

--- a/src/utils/graph_factory.hpp
+++ b/src/utils/graph_factory.hpp
@@ -71,6 +71,7 @@ class GraphFactory {
   using v_desc_t = boost::graph_traits<graph_t>::vertex_descriptor;
   using e_desc_t = boost::graph_traits<graph_t>::edge_descriptor;
 
+  // TODO: gather these JIT-related types into a single file.
   using params_map_t = std::unordered_map <std::string, std::vector<std::string>>;
   using rate_rules_dep_t = std::unordered_map <std::string, std::set<std::string>>;
 


### PR DESCRIPTION
- There were global data structures used in dependency analysis during network initialization.
- These caused race condition with OpenMP, and made the code crash.
- Converted these data structures as member variables of Network class. When each OpenMP thread creates its own network object, it uses its local member data and thus is free of race condition in updating the data.
- This PR depends on PR #89.