### PR TITLE
Define CXX variable in makefile and replace hardcoded paths to the compiler

### DIFF
--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1884,6 +1884,7 @@ std::string generate_cxx_code::gen_makefile()
       extract_file_component(m_lib_filename, dir, stem, ext);
       shared_lib = stem + ext;
 
+      os_makefile << "CXX = " + std::string(CMAKE_CXX_COMPILER) + "\n\n";
       os_makefile << "all: " + shared_lib + "\n\n";
     }
 
@@ -1911,7 +1912,7 @@ std::string generate_cxx_code::gen_makefile()
       const std::string tmp_file = (m_cleanup? src_filename : "");
 
       std::string cmd1
-        = std::string(CMAKE_CXX_COMPILER) + " " + CMAKE_CXX_FLAGS + suppress_warnings
+        = std::string("$(CXX) ") + CMAKE_CXX_FLAGS + suppress_warnings
         + " -fPIC " + WCS_INCLUDE_DIR + CMAKE_CXX_SHARED_LIBRARY_FLAGS
         + " -c " + src_filename + compilation_log;
 
@@ -1923,7 +1924,7 @@ std::string generate_cxx_code::gen_makefile()
 
     { // command for final linking
       std::string cmd2
-        = std::string(CMAKE_CXX_COMPILER) + " " + CMAKE_CXX_FLAGS
+        = std::string("$(CXX) ") + CMAKE_CXX_FLAGS
         + " -fPIC " + CMAKE_CXX_SHARED_LIBRARY_FLAGS
         + " -shared -Wl,--export-dynamic " + obj_files + " -o " + m_lib_filename;
 


### PR DESCRIPTION
Currently, the generated Makefile file used in JIT contains hard-coded paths to the compiler.
Define the variable CXX set to the path of the compiler
and replace the hard-coded paths with the variable