### PR TITLE
use a relative path in the generated makefile

### DIFF
--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -118,6 +118,36 @@ std::string get_default_outname_from_model(const std::string& model_filename)
   }
   return stem + ".out";
 }
+
+/**
+ * For a base path "/a/b/c" and a full path "/a/b/c/d/f.cpp", return "d/f.cpp".
+ * This is useful if the current working directory is the base path.
+ */
+std::string get_subpath(const std::string& basepath,
+                        const std::string& fullpath)
+{
+  std::string dir, stem, ext;
+  extract_file_component(fullpath, dir, stem, ext);
+  auto pos = dir.find(basepath);
+
+  if  (pos == std::string::npos) {
+    return fullpath;
+  }
+
+  auto dir_match = dir.substr(pos);
+
+  if (dir_match.length() < basepath.length()) {
+    return fullpath;
+  }
+  if (((dir_match.length() == basepath.length()) && (basepath.back() == '/')) ||
+      ((dir_match.length() == basepath.length()+1) && (dir_match.back() == '/')))
+  {
+    return stem + ext;
+  }
+
+  return dir_match.substr(basepath.length()) + stem + ext;
+}
+
 /**
  * Create a directory `path` with the given access permission `m`.
  * It is the same as the POSIX mkdir() except that it does not

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -47,6 +47,9 @@ std::string get_libname_from_model(const std::string& model_filename);
 
 std::string get_default_outname_from_model(const std::string& model_filename);
 
+std::string get_subpath(const std::string& basepath,
+                        const std::string& fullpath);
+
 int mkdir_as_needed (const std::string& path, const mode_t m = 0700);
 
 bool sync_directory(const std::string& path);

--- a/src/utils/generate_cxx_code.cpp
+++ b/src/utils/generate_cxx_code.cpp
@@ -1875,7 +1875,8 @@ std::string generate_cxx_code::gen_makefile()
   #pragma omp master
  #endif // defined(_OPENMP)
   {
-    const std::string& hdr_filename = m_ostreams[1].first;
+    const std::string& hdr_filename
+      = get_subpath(m_tmp_dir, m_ostreams[1].first);
     std::ostream& os_makefile = *(m_ostreams[0].second);
     std::string shared_lib;
 
@@ -1894,7 +1895,8 @@ std::string generate_cxx_code::gen_makefile()
     // commands to build object file for each source file
     for (size_t i = 2u; i < m_ostreams.size(); ++i)
     {
-      const std::string& src_filename = m_ostreams[i].first;
+      const std::string& src_filename
+        = get_subpath(m_tmp_dir, m_ostreams[i].first);
 
       // This block updates no state of the current object. It only generates
       // file I/O.


### PR DESCRIPTION
The generated Makefile contains absolute path for source files, which makes it verbose.
As all the source files are written to the temporary directory and the current working directory is set to it, no need to use the length absolute path.