### PR TITLE
Icc workaround

### DIFF
--- a/src/utils/exception.hpp
+++ b/src/utils/exception.hpp
@@ -14,12 +14,19 @@
 #include <iostream>
 #include <exception>
 
+#if 0 // Intel compiler 19.1.2 fails to compile this
 #define WCS_THROW(_MSG_)                                     \
   do {                                                       \
     throw wcs::exception(std::string( __FILE__) + " : line " \
                          + std::to_string(__LINE__) + " : "  \
                          + _MSG_ + '\n');                    \
   } while (0)
+#else
+#define WCS_THROW(_MSG_)                                     \
+    throw wcs::exception(std::string( __FILE__) + " : line " \
+                         + std::to_string(__LINE__) + " : "  \
+                         + _MSG_ + '\n')
+#endif
 
 namespace wcs {
 /** \addtogroup wcs_utils


### PR DESCRIPTION
Intel compiler fails to compile the do-while loop we use for wrapping multi-line macro.
gcc and clang has no problem with it as it should be.
Fortunately, we can use single line macro for the time being.
